### PR TITLE
Disable client and middleware on 404 response from hub

### DIFF
--- a/apitally/client/client_asyncio.py
+++ b/apitally/client/client_asyncio.py
@@ -81,6 +81,7 @@ class ApitallyClient(ApitallyClientBase):
         self._stop_sync_loop = True
 
     async def handle_shutdown(self) -> None:
+        self.enabled = False
         if self._sync_loop_task is not None:
             self._sync_loop_task.cancel()
         # Send any remaining data before exiting
@@ -164,6 +165,7 @@ class ApitallyClient(ApitallyClientBase):
 
     def _handle_hub_response(self, response: httpx.Response) -> None:
         if response.status_code == 404:
+            self.enabled = False
             self.stop_sync_loop()
             logger.error("Invalid Apitally client ID: %s", self.client_id)
         elif response.status_code == 422:

--- a/apitally/client/client_base.py
+++ b/apitally/client/client_base.py
@@ -52,6 +52,7 @@ class ApitallyClientBase(ABC):
 
         self.client_id = client_id
         self.env = env
+        self.enabled = True
         self.instance_uuid = str(uuid4())
         self.request_counter = RequestCounter()
         self.validation_error_counter = ValidationErrorCounter()

--- a/apitally/client/client_threading.py
+++ b/apitally/client/client_threading.py
@@ -190,6 +190,7 @@ class ApitallyClient(ApitallyClientBase):
 
     def _handle_hub_response(self, response: requests.Response) -> None:
         if response.status_code == 404:
+            self.enabled = False
             self.stop_sync_loop()
             logger.error("Invalid Apitally client ID: %s", self.client_id)
         elif response.status_code == 422:

--- a/apitally/django.py
+++ b/apitally/django.py
@@ -113,7 +113,7 @@ class ApitallyMiddleware:
         )
 
     def __call__(self, request: HttpRequest) -> HttpResponse:
-        if request.method is not None and request.method != "OPTIONS":
+        if self.client.enabled and request.method is not None and request.method != "OPTIONS":
             timestamp = time.time()
             request_size = parse_int(request.headers.get("Content-Length"))
             request_body = b""

--- a/apitally/flask.py
+++ b/apitally/flask.py
@@ -74,6 +74,9 @@ class ApitallyMiddleware:
         self.client.set_startup_data(data)
 
     def __call__(self, environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[bytes]:
+        if not self.client.enabled:
+            return self.wsgi_app(environ, start_response)
+
         timestamp = time.time()
         response_headers = Headers([])
         status_code = 0

--- a/apitally/litestar.py
+++ b/apitally/litestar.py
@@ -86,7 +86,7 @@ class ApitallyPlugin(InitPluginProtocol):
 
     def middleware_factory(self, app: ASGIApp) -> ASGIApp:
         async def middleware(scope: Scope, receive: Receive, send: Send) -> None:
-            if scope["type"] == "http" and scope["method"] != "OPTIONS":
+            if self.client.enabled and scope["type"] == "http" and scope["method"] != "OPTIONS":
                 timestamp = time.time()
                 request = Request(scope)
                 request_size = parse_int(request.headers.get("Content-Length"))

--- a/apitally/starlette.py
+++ b/apitally/starlette.py
@@ -73,7 +73,7 @@ class ApitallyMiddleware:
         self.client.set_startup_data(data)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope["type"] == "http" and scope["method"] != "OPTIONS":
+        if self.client.enabled and scope["type"] == "http" and scope["method"] != "OPTIONS":
             timestamp = time.time()
             request = Request(scope)
             request_size = parse_int(request.headers.get("Content-Length"))

--- a/tests/test_litestar.py
+++ b/tests/test_litestar.py
@@ -30,7 +30,9 @@ async def app(module_mocker: MockerFixture) -> Litestar:
 
     from apitally.litestar import ApitallyConsumer, ApitallyPlugin, RequestLoggingConfig
 
-    async def mocked_handle_shutdown():
+    async def mocked_handle_shutdown(_):
+        # Empty function instead of Mock to avoid the following error in Python 3.10:
+        # TypeError: 'Mock' object is not subscriptable
         pass
 
     module_mocker.patch("apitally.client.client_asyncio.ApitallyClient._instance", None)

--- a/tests/test_litestar.py
+++ b/tests/test_litestar.py
@@ -33,6 +33,7 @@ async def app(module_mocker: MockerFixture) -> Litestar:
     module_mocker.patch("apitally.client.client_asyncio.ApitallyClient._instance", None)
     module_mocker.patch("apitally.client.client_asyncio.ApitallyClient.start_sync_loop")
     module_mocker.patch("apitally.client.client_asyncio.ApitallyClient.set_startup_data")
+    module_mocker.patch("apitally.client.client_asyncio.ApitallyClient.handle_shutdown")
 
     @get("/foo")
     async def foo() -> str:

--- a/tests/test_litestar.py
+++ b/tests/test_litestar.py
@@ -30,10 +30,13 @@ async def app(module_mocker: MockerFixture) -> Litestar:
 
     from apitally.litestar import ApitallyConsumer, ApitallyPlugin, RequestLoggingConfig
 
+    async def mocked_handle_shutdown():
+        pass
+
     module_mocker.patch("apitally.client.client_asyncio.ApitallyClient._instance", None)
     module_mocker.patch("apitally.client.client_asyncio.ApitallyClient.start_sync_loop")
     module_mocker.patch("apitally.client.client_asyncio.ApitallyClient.set_startup_data")
-    module_mocker.patch("apitally.client.client_asyncio.ApitallyClient.handle_shutdown")
+    module_mocker.patch("apitally.client.client_asyncio.ApitallyClient.handle_shutdown", mocked_handle_shutdown)
 
     @get("/foo")
     async def foo() -> str:


### PR DESCRIPTION
This prevents a memory leak due to the client not syncing and clearing memory, while the middleware continues to write to it.