### PR TITLE
Don't read response body if unsupported content type

### DIFF
--- a/apitally/client/request_logging.py
+++ b/apitally/client/request_logging.py
@@ -312,13 +312,17 @@ class RequestLogger:
         return False
 
     @staticmethod
-    def _has_supported_content_type(headers: List[Tuple[str, str]]) -> bool:
-        content_type = next((v for k, v in headers if k.lower() == "content-type"), None)
-        return content_type is not None and any(content_type.startswith(t) for t in ALLOWED_CONTENT_TYPES)
-
-    @staticmethod
     def _get_user_agent(headers: List[Tuple[str, str]]) -> Optional[str]:
         return next((v for k, v in headers if k.lower() == "user-agent"), None)
+
+    @staticmethod
+    def _has_supported_content_type(headers: List[Tuple[str, str]]) -> bool:
+        content_type = next((v for k, v in headers if k.lower() == "content-type"), None)
+        return RequestLogger.is_supported_content_type(content_type)
+
+    @staticmethod
+    def is_supported_content_type(content_type: Optional[str]) -> bool:
+        return content_type is not None and any(content_type.startswith(t) for t in ALLOWED_CONTENT_TYPES)
 
 
 def _check_writable_fs() -> bool:

--- a/apitally/django.py
+++ b/apitally/django.py
@@ -19,6 +19,7 @@ from apitally.client.logging import get_logger
 from apitally.client.request_logging import (
     BODY_TOO_LARGE,
     MAX_BODY_SIZE,
+    RequestLogger,
     RequestLoggingConfig,
 )
 from apitally.common import get_versions, parse_int
@@ -133,7 +134,12 @@ class ApitallyMiddleware:
                 else (len(response.content) if not response.streaming else None)
             )
             response_body = b""
-            if self.capture_response_body and not response.streaming:
+            response_content_type = response.get("Content-Type")
+            if (
+                self.capture_response_body
+                and not response.streaming
+                and RequestLogger.is_supported_content_type(response_content_type)
+            ):
                 response_body = (
                     response.content if response_size is not None and response_size <= MAX_BODY_SIZE else BODY_TOO_LARGE
                 )

--- a/apitally/flask.py
+++ b/apitally/flask.py
@@ -17,6 +17,7 @@ from apitally.client.consumers import Consumer as ApitallyConsumer
 from apitally.client.request_logging import (
     BODY_TOO_LARGE,
     MAX_BODY_SIZE,
+    RequestLogger,
     RequestLoggingConfig,
 )
 from apitally.common import get_versions
@@ -103,7 +104,8 @@ class ApitallyMiddleware:
             response_time = time.perf_counter() - start_time
 
             response_body = b""
-            if self.capture_response_body:
+            response_content_type = response_headers.get("Content-Type")
+            if self.capture_response_body and RequestLogger.is_supported_content_type(response_content_type):
                 response_size = response_headers.get("Content-Length", type=int)
                 if response_size is not None and response_size > MAX_BODY_SIZE:
                     response_body = BODY_TOO_LARGE

--- a/apitally/litestar.py
+++ b/apitally/litestar.py
@@ -19,6 +19,7 @@ from apitally.client.consumers import Consumer as ApitallyConsumer
 from apitally.client.request_logging import (
     BODY_TOO_LARGE,
     MAX_BODY_SIZE,
+    RequestLogger,
     RequestLoggingConfig,
 )
 from apitally.common import get_versions, parse_int
@@ -99,6 +100,7 @@ class ApitallyPlugin(InitPluginProtocol):
                 response_body_too_large = False
                 response_size: Optional[int] = None
                 response_chunked = False
+                response_content_type: Optional[str] = None
                 start_time = time.perf_counter()
 
                 async def receive_wrapper() -> Message:
@@ -119,6 +121,7 @@ class ApitallyPlugin(InitPluginProtocol):
                         response_body, \
                         response_body_too_large, \
                         response_chunked, \
+                        response_content_type, \
                         response_size
                     if message["type"] == "http.response.start":
                         response_time = time.perf_counter() - start_time
@@ -128,12 +131,17 @@ class ApitallyPlugin(InitPluginProtocol):
                             response_headers.get("Transfer-Encoding") == "chunked"
                             or "Content-Length" not in response_headers
                         )
+                        response_content_type = response_headers.get("Content-Type")
                         response_size = parse_int(response_headers.get("Content-Length")) if not response_chunked else 0
                         response_body_too_large = response_size is not None and response_size > MAX_BODY_SIZE
                     elif message["type"] == "http.response.body":
                         if response_chunked and response_size is not None:
                             response_size += len(message.get("body", b""))
-                        if (self.capture_response_body or response_status == 400) and not response_body_too_large:
+                        if (
+                            (self.capture_response_body or response_status == 400)
+                            and RequestLogger.is_supported_content_type(response_content_type)
+                            and not response_body_too_large
+                        ):
                             response_body += message.get("body", b"")
                             if len(response_body) > MAX_BODY_SIZE:
                                 response_body_too_large = True

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -42,12 +42,12 @@ def app(module_mocker: MockerFixture) -> Flask:
     @app.route("/foo/<bar>")
     def foo_bar(bar: int):
         g.apitally_consumer = "test"
-        return f"foo: {bar}"
+        return f"foo: {bar}", {"Content-Type": "text/plain"}
 
     @app.route("/bar", methods=["POST"])
     def bar():
         body = request.get_data()
-        return "bar: " + body.decode()
+        return "bar: " + body.decode(), {"Content-Type": "text/plain"}
 
     @app.route("/baz", methods=["PUT"])
     def baz():
@@ -123,7 +123,7 @@ def test_middleware_request_logging(app: Flask, mocker: MockerFixture):
     assert ("Test-Header", "test") in mock.call_args.kwargs["request"]["headers"]
     assert mock.call_args.kwargs["response"]["status_code"] == 200
     assert mock.call_args.kwargs["response"]["response_time"] > 0
-    assert ("Content-Type", "text/html; charset=utf-8") in mock.call_args.kwargs["response"]["headers"]
+    assert ("Content-Type", "text/plain") in mock.call_args.kwargs["response"]["headers"]
     assert mock.call_args.kwargs["response"]["size"] > 0
 
     response = client.post("/bar", data=b"foo")


### PR DESCRIPTION
Prevent loading response body into memory temporarily if the content type is not supported anyway.