### PR TITLE
Add set_consumer helper functions

### DIFF
--- a/apitally/fastapi.py
+++ b/apitally/fastapi.py
@@ -1,4 +1,4 @@
-from apitally.starlette import ApitallyConsumer, ApitallyMiddleware, RequestLoggingConfig
+from apitally.starlette import ApitallyConsumer, ApitallyMiddleware, RequestLoggingConfig, set_consumer
 
 
-__all__ = ["ApitallyMiddleware", "ApitallyConsumer", "RequestLoggingConfig"]
+__all__ = ["ApitallyMiddleware", "ApitallyConsumer", "RequestLoggingConfig", "set_consumer"]

--- a/apitally/flask.py
+++ b/apitally/flask.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
     from werkzeug.routing.map import Map
 
 
-__all__ = ["ApitallyMiddleware", "ApitallyConsumer", "RequestLoggingConfig"]
+__all__ = ["ApitallyMiddleware", "ApitallyConsumer", "RequestLoggingConfig", "set_consumer"]
 
 
 class ApitallyMiddleware:
@@ -214,6 +214,10 @@ class ApitallyMiddleware:
             )
             return ApitallyConsumer.from_string_or_object(g.consumer_identifier)
         return None
+
+
+def set_consumer(identifier: str, name: Optional[str] = None, group: Optional[str] = None) -> None:
+    g.apitally_consumer = ApitallyConsumer(identifier, name=name, group=group)
 
 
 def _get_startup_data(

--- a/apitally/litestar.py
+++ b/apitally/litestar.py
@@ -24,7 +24,7 @@ from apitally.client.request_logging import (
 from apitally.common import get_versions, parse_int, try_json_loads
 
 
-__all__ = ["ApitallyPlugin", "ApitallyConsumer", "RequestLoggingConfig"]
+__all__ = ["ApitallyPlugin", "ApitallyConsumer", "RequestLoggingConfig", "set_consumer"]
 
 
 class ApitallyPlugin(InitPluginProtocol):
@@ -285,6 +285,10 @@ class ApitallyPlugin(InitPluginProtocol):
             consumer = self.identify_consumer_callback(request)
             return ApitallyConsumer.from_string_or_object(consumer)
         return None
+
+
+def set_consumer(request: Request, identifier: str, name: Optional[str] = None, group: Optional[str] = None) -> None:
+    request.state.apitally_consumer = ApitallyConsumer(identifier, name=name, group=group)
 
 
 def _get_openapi(app: Litestar) -> str:

--- a/apitally/starlette.py
+++ b/apitally/starlette.py
@@ -25,7 +25,7 @@ from apitally.client.request_logging import (
 from apitally.common import get_versions, parse_int, try_json_loads
 
 
-__all__ = ["ApitallyMiddleware", "ApitallyConsumer", "RequestLoggingConfig"]
+__all__ = ["ApitallyMiddleware", "ApitallyConsumer", "RequestLoggingConfig", "set_consumer"]
 
 
 class ApitallyMiddleware:
@@ -266,6 +266,10 @@ class ApitallyMiddleware:
             consumer = self.identify_consumer_callback(request)
             return ApitallyConsumer.from_string_or_object(consumer)
         return None
+
+
+def set_consumer(request: Request, identifier: str, name: Optional[str] = None, group: Optional[str] = None) -> None:
+    request.state.apitally_consumer = ApitallyConsumer(identifier, name=name, group=group)
 
 
 def _get_startup_data(

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -18,9 +18,9 @@ if TYPE_CHECKING:
 
 @pytest.fixture(scope="module")
 def app(module_mocker: MockerFixture) -> Flask:
-    from flask import Flask, g, request
+    from flask import Flask, request
 
-    from apitally.flask import ApitallyMiddleware, RequestLoggingConfig
+    from apitally.flask import ApitallyMiddleware, RequestLoggingConfig, set_consumer
 
     module_mocker.patch("apitally.client.client_threading.ApitallyClient._instance", None)
     module_mocker.patch("apitally.client.client_threading.ApitallyClient.start_sync_loop")
@@ -41,7 +41,7 @@ def app(module_mocker: MockerFixture) -> Flask:
 
     @app.route("/foo/<bar>")
     def foo_bar(bar: int):
-        g.apitally_consumer = "test"
+        set_consumer("test")
         return f"foo: {bar}", {"Content-Type": "text/plain"}
 
     @app.route("/bar", methods=["POST"])

--- a/tests/test_litestar.py
+++ b/tests/test_litestar.py
@@ -28,7 +28,7 @@ async def app(module_mocker: MockerFixture) -> Litestar:
     from litestar.handlers import get, post
     from litestar.response import Stream
 
-    from apitally.litestar import ApitallyConsumer, ApitallyPlugin, RequestLoggingConfig
+    from apitally.litestar import ApitallyConsumer, ApitallyPlugin, RequestLoggingConfig, set_consumer
 
     async def mocked_handle_shutdown(_):
         # Empty function instead of Mock to avoid the following error in Python 3.10:
@@ -45,7 +45,7 @@ async def app(module_mocker: MockerFixture) -> Litestar:
 
     @get("/foo/{bar:str}")
     async def foo_bar(request: Request, bar: str) -> str:
-        request.state.apitally_consumer = "test2"
+        set_consumer(request, "test2")
         return f"foo: {bar}"
 
     @post("/bar")

--- a/tests/test_starlette.py
+++ b/tests/test_starlette.py
@@ -41,10 +41,10 @@ def get_starlette_app() -> Starlette:
     from starlette.responses import PlainTextResponse, StreamingResponse
     from starlette.routing import Mount, Route
 
-    from apitally.starlette import ApitallyConsumer, ApitallyMiddleware, RequestLoggingConfig
+    from apitally.starlette import ApitallyConsumer, ApitallyMiddleware, RequestLoggingConfig, set_consumer
 
     def foo(request: Request):
-        request.state.apitally_consumer = "test"
+        set_consumer(request, "test")
         return PlainTextResponse("foo")
 
     def foo_bar(request: Request):


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced a new `set_consumer` function for FastAPI, Flask, Litestar, and Starlette integrations, allowing easier assignment of consumer information within requests.

* **Tests**
  * Updated tests to use the new `set_consumer` function for setting consumer details, ensuring consistency across supported frameworks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->