### PR TITLE
Always exclude OPTIONS requests

### DIFF
--- a/apitally/blacksheep.py
+++ b/apitally/blacksheep.py
@@ -128,7 +128,7 @@ class ApitallyMiddleware:
         return None
 
     async def __call__(self, request: Request, handler: Callable[[Request], Awaitable[Response]]) -> Response:
-        if not self.client.enabled:
+        if not self.client.enabled or request.method.upper() == "OPTIONS":
             return await handler(request)
 
         timestamp = time.time()
@@ -188,7 +188,7 @@ class ApitallyMiddleware:
                         if response_size is None or response_size < 0:
                             response_size = len(response_body)
 
-            if route_pattern and request.method.upper() != "OPTIONS":
+            if route_pattern:
                 self.client.request_counter.add_request(
                     consumer=consumer_identifier,
                     method=request.method.upper(),
@@ -251,7 +251,7 @@ def _get_startup_data(app: Application, app_version: Optional[str] = None) -> Di
 def _get_paths(app: Application) -> List[Dict[str, str]]:
     openapi = OpenAPIHandler(info=Info(title="", version=""))
     paths = []
-    methods = ("get", "put", "post", "delete", "options", "head", "patch", "trace")
+    methods = ("get", "put", "post", "delete", "patch")
     for path, path_item in openapi.get_paths(app).items():
         for method in methods:
             operation: Operation = getattr(path_item, method, None)

--- a/apitally/flask.py
+++ b/apitally/flask.py
@@ -102,7 +102,7 @@ class ApitallyMiddleware:
         self.client.start_sync_loop()
 
     def __call__(self, environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[bytes]:
-        if not self.client.enabled:
+        if not self.client.enabled or environ.get("REQUEST_METHOD") == "OPTIONS":
             return self.wsgi_app(environ, start_response)
 
         timestamp = time.time()
@@ -180,7 +180,7 @@ class ApitallyMiddleware:
         consumer_identifier = consumer.identifier if consumer else None
         self.client.consumer_registry.add_or_update_consumer(consumer)
 
-        if path is not None and request.method != "OPTIONS":
+        if path is not None:
             self.client.request_counter.add_request(
                 consumer=consumer_identifier,
                 method=request.method,

--- a/apitally/litestar.py
+++ b/apitally/litestar.py
@@ -327,5 +327,5 @@ def _get_routes(app: Litestar) -> List[Dict[str, str]]:
         {"method": method, "path": route.path}
         for route in app.routes
         for method in route.methods
-        if route.scope_type == ScopeType.HTTP and method != "OPTIONS"
+        if route.scope_type == ScopeType.HTTP and method not in ["OPTIONS", "HEAD"]
     ]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request handling to bypass processing for HTTP OPTIONS requests in middleware.
  * Adjusted metrics collection to include or exclude certain HTTP methods as appropriate, refining which requests are counted and which are instrumented.

* **Refactor**
  * Updated filtering logic to exclude specific HTTP methods (OPTIONS, HEAD, TRACE) from certain operations and route listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->