### PR TITLE
Handle proxy objects in Django schema

### DIFF
--- a/apitally/django.py
+++ b/apitally/django.py
@@ -12,6 +12,7 @@ from warnings import warn
 from django.conf import settings
 from django.contrib.admindocs.views import extract_views_from_urlpatterns, simplify_regex
 from django.urls import URLPattern, URLResolver, get_resolver
+from django.utils.functional import Promise
 from django.utils.module_loading import import_string
 from django.views.generic.base import View
 
@@ -500,12 +501,9 @@ def _check_import(name: str) -> bool:
 
 
 def _convert_proxy_objects(data: Any) -> Any:
-    """
-    Recursively convert Django proxy objects to their string representation
-    to make them JSON serializable.
-    """
-    if hasattr(data, "_delegate_text") or hasattr(data, "_delegate_bytes"):
-        # This is a Django proxy object (like ugettext_lazy)
+    """Recursively convert Django proxy objects to string to make them JSON serializable."""
+    if isinstance(data, Promise):
+        # This is a Django proxy object
         return _force_text_compat(data)
     elif isinstance(data, dict):
         return {key: _convert_proxy_objects(value) for key, value in data.items()}

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -207,3 +207,27 @@ def test_check_import():
 
     assert _check_import("ninja") is True
     assert _check_import("nonexistentpackage") is False
+
+
+def test_convert_proxy_objects():
+    from django.utils.functional import lazy
+
+    from apitally.django import _convert_proxy_objects
+
+    lazy_string = lazy(lambda: "Hello, World!", str)()
+    assert _convert_proxy_objects(lazy_string) == "Hello, World!"
+
+    data = {
+        "title": lazy_string,
+        "description": "Normal string",
+        "nested": {"summary": lazy_string, "items": [lazy_string, "normal string"]},
+    }
+    result = _convert_proxy_objects(data)
+    assert result["title"] == "Hello, World!"
+    assert result["description"] == "Normal string"
+    assert result["nested"]["summary"] == "Hello, World!"
+    assert result["nested"]["items"][0] == "Hello, World!"
+    assert result["nested"]["items"][1] == "normal string"
+
+    data = {"key": "value", "number": 42}
+    assert _convert_proxy_objects(data) == data

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -218,20 +218,15 @@ def test_convert_proxy_objects():
     assert _convert_proxy_objects(lazy_string) == "Hello, World!"
 
     data = {
-        "title": lazy_string,
-        "description": "Normal string",
-        "nested": {"summary": lazy_string, "items": [lazy_string, "normal string"]},
+        "lazy": lazy_string,
+        "normal": "Normal string",
+        "nested": {"lazy": lazy_string, "items": [lazy_string, "normal string"]},
+        "tuple": (lazy_string, "normal", lazy_string),
     }
     result = _convert_proxy_objects(data)
-    assert result["title"] == "Hello, World!"
-    assert result["description"] == "Normal string"
-    assert result["nested"]["summary"] == "Hello, World!"
+    assert result["lazy"] == "Hello, World!"
+    assert result["normal"] == "Normal string"
+    assert result["nested"]["lazy"] == "Hello, World!"
     assert result["nested"]["items"][0] == "Hello, World!"
     assert result["nested"]["items"][1] == "normal string"
-
-    data = (lazy_string, "normal", lazy_string)
-    result = _convert_proxy_objects(data)
-    assert result == ("Hello, World!", "normal", "Hello, World!")
-
-    data = {"key": "value", "number": 42}
-    assert _convert_proxy_objects(data) == data
+    assert result["tuple"] == ("Hello, World!", "normal", "Hello, World!")

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -229,5 +229,9 @@ def test_convert_proxy_objects():
     assert result["nested"]["items"][0] == "Hello, World!"
     assert result["nested"]["items"][1] == "normal string"
 
+    data = (lazy_string, "normal", lazy_string)
+    result = _convert_proxy_objects(data)
+    assert result == ("Hello, World!", "normal", "Hello, World!")
+
     data = {"key": "value", "number": 42}
     assert _convert_proxy_objects(data) == data


### PR DESCRIPTION
Fixes #128 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility when exporting OpenAPI schemas by converting lazy translation proxy objects to strings, preventing serialization errors.

* **Tests**
  * Added tests to ensure proper conversion of lazy translation proxy objects in different data structures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->