### PR TITLE
Fix getting OpenAPI schema with drf-spectacular

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Install dependencies
         run: |
           uv sync --all-extras --frozen
-          uv pip install drf-spectacular inflection uritemplate
+          uv pip install drf-spectacular
       - name: Run checks
         run: uv run make check
       - name: Run tests and create coverage report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,9 @@ jobs:
       - name: Install Python
         run: uv python install 3.13
       - name: Install dependencies
-        run: uv sync --all-extras --frozen
+        run: |
+          uv sync --all-extras --frozen
+          uv pip install drf-spectacular inflection uritemplate
       - name: Run checks
         run: uv run make check
       - name: Run tests and create coverage report

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -53,6 +53,7 @@ jobs:
           - flask
           - flask==2.3.*
           - flask==2.0.3 Werkzeug==2.*
+          - djangorestframework drf-spectacular django
           - djangorestframework django uritemplate inflection
           - djangorestframework django==4.2.* uritemplate inflection
           - djangorestframework==3.12.* django==3.2.* uritemplate

--- a/apitally/django.py
+++ b/apitally/django.py
@@ -403,7 +403,7 @@ def _get_drf_schema(urlconfs: List[Optional[str]]) -> Optional[Dict[str, Any]]:
 
 
 def _get_drf_spectacular_schema(urlconfs: List[Optional[str]]) -> Optional[Dict[str, Any]]:
-    from drf_spectacular.generators import SchemaGenerator
+    from drf_spectacular.generators import SchemaGenerator  # type: ignore[import-not-found]
 
     schemas = []
     for urlconf in urlconfs:

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -24,7 +24,7 @@ def identify_consumer(request: HttpRequest) -> Optional[str]:
 @pytest.fixture(scope="module")
 def reset_modules() -> None:
     for module in list(sys.modules):
-        if module.startswith("django.") or module.startswith("apitally.") or module.startswith("tests."):
+        if module.startswith("django.") or module.startswith("apitally."):
             del sys.modules[module]
 
 

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -24,7 +24,7 @@ def identify_consumer(request: HttpRequest) -> Optional[str]:
 @pytest.fixture(scope="module")
 def reset_modules() -> None:
     for module in list(sys.modules):
-        if module.startswith("django.") or module.startswith("apitally."):
+        if module.startswith("django.") or module.startswith("apitally.") or module.startswith("tests."):
             del sys.modules[module]
 
 

--- a/tests/test_django_rest_framework.py
+++ b/tests/test_django_rest_framework.py
@@ -23,7 +23,7 @@ def reset_modules() -> None:
             module.startswith("django.")
             or module.startswith("rest_framework.")
             or module.startswith("apitally.")
-            or module.startswith("tests.")
+            or module == "tests.django_rest_framework_urls"
         ):
             del sys.modules[module]
 

--- a/tests/test_django_rest_framework.py
+++ b/tests/test_django_rest_framework.py
@@ -19,7 +19,12 @@ if TYPE_CHECKING:
 @pytest.fixture(scope="module")
 def reset_modules() -> None:
     for module in list(sys.modules):
-        if module.startswith("django.") or module.startswith("rest_framework.") or module.startswith("apitally."):
+        if (
+            module.startswith("django.")
+            or module.startswith("rest_framework.")
+            or module.startswith("apitally.")
+            or module.startswith("tests.")
+        ):
             del sys.modules[module]
 
 

--- a/tests/test_drf_spectacular.py
+++ b/tests/test_drf_spectacular.py
@@ -19,7 +19,7 @@ def reset_modules() -> None:
             module.startswith("django.")
             or module.startswith("rest_framework.")
             or module.startswith("apitally.")
-            or module.startswith("tests.")
+            or module == "tests.django_rest_framework_urls"
         ):
             del sys.modules[module]
 

--- a/tests/test_drf_spectacular.py
+++ b/tests/test_drf_spectacular.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import sys
+from importlib.util import find_spec
+
+import pytest
+from pytest_mock import MockerFixture
+
+
+if find_spec("drf_spectacular") is None:
+    pytest.skip("drf-spectacular is not available", allow_module_level=True)
+
+
+@pytest.fixture(scope="module")
+def reset_modules() -> None:
+    for module in list(sys.modules):
+        if module.startswith("django.") or module.startswith("rest_framework.") or module.startswith("apitally."):
+            del sys.modules[module]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def setup(reset_modules, module_mocker: MockerFixture) -> None:
+    import django
+    from django.conf import settings
+
+    module_mocker.patch("apitally.client.client_threading.ApitallyClient._instance", None)
+    module_mocker.patch("apitally.client.client_threading.ApitallyClient.start_sync_loop")
+    module_mocker.patch("apitally.client.client_threading.ApitallyClient.set_startup_data")
+    module_mocker.patch("apitally.django.ApitallyMiddleware.config", None)
+
+    settings.configure(
+        ROOT_URLCONF="tests.django_rest_framework_urls",
+        ALLOWED_HOSTS=["testserver"],
+        SECRET_KEY="secret",
+        MIDDLEWARE=[
+            "apitally.django_rest_framework.ApitallyMiddleware",
+            "django.middleware.common.CommonMiddleware",
+        ],
+        INSTALLED_APPS=[
+            "django.contrib.auth",
+            "django.contrib.contenttypes",
+            "rest_framework",
+            "drf_spectacular",
+        ],
+        REST_FRAMEWORK={
+            "DEFAULT_SCHEMA_CLASS": "drf_spectacular.openapi.AutoSchema",
+        },
+        APITALLY_MIDDLEWARE={
+            "client_id": "76b5cb91-a0a4-4ea0-a894-57d2b9fcb2c9",
+            "env": "dev",
+        },
+    )
+    django.setup()
+
+
+def test_get_startup_data():
+    from apitally.django import _get_startup_data
+
+    data = _get_startup_data(app_version="1.2.3", urlconfs=[None])
+    openapi = json.loads(data["openapi"])
+    assert len(data["paths"]) == 4
+    assert len(openapi["paths"]) == 4

--- a/tests/test_drf_spectacular.py
+++ b/tests/test_drf_spectacular.py
@@ -15,7 +15,12 @@ if find_spec("drf_spectacular") is None:
 @pytest.fixture(scope="module")
 def reset_modules() -> None:
     for module in list(sys.modules):
-        if module.startswith("django.") or module.startswith("rest_framework.") or module.startswith("apitally."):
+        if (
+            module.startswith("django.")
+            or module.startswith("rest_framework.")
+            or module.startswith("apitally.")
+            or module.startswith("tests.")
+        ):
             del sys.modules[module]
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for generating OpenAPI schemas using DRF Spectacular, providing an alternative to the default schema generator.

* **Tests**
  * Introduced new tests to verify integration with DRF Spectacular and ensure correct schema generation.
  * Updated test fixtures to improve module cleanup and isolation during testing.

* **Chores**
  * Updated CI workflow to include DRF Spectacular in the test matrix for broader compatibility coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->