### PR TITLE
Pin pytest and pytest-httpx in Renovate to keep Python 3.9 support

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,15 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>apitally/renovate-config"],
-  "ignoreDeps": ["pytest-asyncio"]
+  "ignoreDeps": ["pytest-asyncio"],
+  "packageRules": [
+    {
+      "matchPackageNames": ["pytest"],
+      "allowedVersions": "<9"
+    },
+    {
+      "matchPackageNames": ["pytest-httpx"],
+      "allowedVersions": "<0.36"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

Two Renovate PRs are currently failing CI:

- #271 — bump pytest-httpx `~=0.33.0` → `~=0.36.2`
- #267 — bump pytest `~=8.4.0` → `~=9.0.3` (security update for CVE-2025-71176)

**Root cause:** pytest 9 dropped support for Python 3.9, and pytest-httpx 0.36 in turn requires pytest 9. Apitally still declares `requires-python = ">=3.9,<4.0"`, so neither upgrade can be resolved.

This PR adds `packageRules` to `renovate.json` constraining:
- `pytest` < 9
- `pytest-httpx` < 0.36

so Renovate stops opening these PRs while we still support Python 3.9.

Both Renovate PRs will be closed alongside this.

## Test plan
- [ ] Renovate config validates on next run (Renovate auto-validates JSON schema)
- [ ] No new PRs opened for `pytest` ≥ 9 or `pytest-httpx` ≥ 0.36

https://claude.ai/code/session_01D7U46uD9XeErH1CWcdXLAm

---
_Generated by [Claude Code](https://claude.ai/code/session_01D7U46uD9XeErH1CWcdXLAm)_

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update Renovate to stop opening PRs that upgrade `pytest`/`pytest-httpx` beyond Python 3.9 support. Keeps CI green while we still support 3.9.

- **Dependencies**
  - Pin `pytest` to `<9` via Renovate `packageRules`
  - Pin `pytest-httpx` to `<0.36` via Renovate `packageRules`

<sup>Written for commit 8978ad7db6807c38f769b9820a50d02098f9269f. Summary will update on new commits. <a href="https://cubic.dev/pr/apitally/apitally-py/pull/290?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

