### PR TITLE
Fix Starlette route resolution for FastAPI 0.138+ included routers

### DIFF
--- a/apitally/starlette.py
+++ b/apitally/starlette.py
@@ -11,14 +11,14 @@ from httpx import HTTPStatusError, Proxy
 from starlette.applications import Starlette
 from starlette.datastructures import Headers
 from starlette.requests import Request
-from starlette.routing import BaseRoute, Match, Router
+from starlette.routing import BaseRoute, Match, Route, Router
 from starlette.schemas import EndpointInfo, SchemaGenerator
 from starlette.testclient import TestClient
 from starlette.types import ASGIApp, Lifespan, Message, Receive, Scope, Send
 
 from apitally.client.client_asyncio import ApitallyClient
 from apitally.client.consumers import Consumer as ApitallyConsumer
-from apitally.client.logging import LogHandler, setup_log_capture
+from apitally.client.logging import LogHandler, get_logger, setup_log_capture
 from apitally.client.request_logging import (
     BODY_TOO_LARGE,
     MAX_BODY_SIZE,
@@ -36,6 +36,8 @@ except ImportError:
 
 
 __all__ = ["ApitallyMiddleware", "ApitallyConsumer", "RequestLoggingConfig", "set_consumer"]
+
+logger = get_logger(__name__)
 
 
 class ApitallyMiddleware:
@@ -285,6 +287,11 @@ class ApitallyMiddleware:
 
     def get_route_path(self, request: Request, routes: Optional[list[BaseRoute]] = None) -> Optional[str]:
         if routes is None:
+            # FastAPI 0.138+ stores the resolved route (with the full path) in the scope
+            route_context = request.scope.get("fastapi", {}).get("effective_route_context")
+            route_path = getattr(route_context, "path", None)
+            if route_path:
+                return request.scope.get("root_path", "") + route_path
             routes = request.app.routes
         for route in routes:
             if hasattr(route, "routes"):
@@ -323,8 +330,12 @@ def _get_startup_data(
     data: dict[str, Any] = {}
     if openapi_url and (openapi := _get_openapi(app, openapi_url)):
         data["openapi"] = openapi
-    if endpoints := _get_endpoint_info(app):
-        data["paths"] = [{"path": endpoint.path, "method": endpoint.http_method} for endpoint in endpoints]
+    try:
+        data["paths"] = [
+            {"path": endpoint.path, "method": endpoint.http_method} for endpoint in _get_endpoint_info(app)
+        ]
+    except Exception:  # pragma: no cover
+        logger.exception("Failed to get list of endpoints")
     data["versions"] = get_versions("fastapi", "starlette", app_version=app_version)
     data["client"] = "python:starlette"
     return data
@@ -347,11 +358,31 @@ def _get_endpoint_info(app: ASGIApp) -> list[EndpointInfo]:
 
 
 def _get_routes(app: Union[ASGIApp, Router]) -> list[BaseRoute]:
-    if isinstance(app, Router):
-        return app.routes
-    elif hasattr(app, "app"):
-        return _get_routes(app.app)  # ty: ignore[invalid-argument-type]
-    return []  # pragma: no cover
+    if not isinstance(app, Router):
+        if hasattr(app, "app"):
+            return _get_routes(app.app)  # ty: ignore[invalid-argument-type]
+        return []  # pragma: no cover
+    routes = []
+    for route in app.routes:
+        # FastAPI 0.138+ no longer flattens included routers into `app.routes`, and Starlette's
+        # SchemaGenerator doesn't understand them, so expand them into their underlying routes
+        effective_route_contexts = getattr(route, "effective_route_contexts", None)
+        if not callable(effective_route_contexts):
+            routes.append(route)
+            continue
+        for context in effective_route_contexts():
+            if context.starlette_route is not None:
+                routes.append(context.starlette_route)
+            elif context.path and context.endpoint is not None:
+                routes.append(
+                    Route(
+                        context.path,
+                        endpoint=context.endpoint,
+                        methods=list(context.methods or []),
+                        include_in_schema=context.include_in_schema,
+                    )
+                )
+    return routes
 
 
 def _inject_lifespan_handlers(

--- a/uv.lock
+++ b/uv.lock
@@ -869,7 +869,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.136.3"
+version = "0.138.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -878,9 +878,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/81/2d/ff8d91d7b564d464629a0fd50a4489c97fcb836ac230bf3a7269232a9b1f/fastapi-0.136.3.tar.gz", hash = "sha256:e487fae93ad408e6f47641ee4dfe389864fd7bec92e547ea8498fc13f43e83ab", size = 396410, upload-time = "2026-05-23T18:53:15.192Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8a/c9/5e8defe249899c0dc900643695fc07829a67fc88b4ff2cdb03fcbdbf5a4b/fastapi-0.138.1.tar.gz", hash = "sha256:96e3702dce09ee0dce48856135620d3d865ca684a79fe7513fd7b13a12f82862", size = 419646, upload-time = "2026-06-25T15:40:42.115Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/82/45359b62a067409bd929ae8a56b8ed13e5a8c8a61194b3c236920999ab83/fastapi-0.136.3-py3-none-any.whl", hash = "sha256:3d2a69bdf04b7e9f3afa292c3bc7a98816bbfafa10bc9b45f3f3700d2f761620", size = 117481, upload-time = "2026-05-23T18:53:16.924Z" },
+    { url = "https://files.pythonhosted.org/packages/38/a9/69a6924f645eb4dd8cd625bf255b3625990eb3e14e073438a53c405dcd3e/fastapi-0.138.1-py3-none-any.whl", hash = "sha256:b994cae7ba8b82c976a728b544244de31333fa5f7d261f9a1dffe526444cae23", size = 129182, upload-time = "2026-06-25T15:40:40.771Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

FastAPI 0.138+ no longer flattens `include_router()`-ed routers into `app.routes`. As a result, Apitally could not resolve the path or endpoints of routes defined under an included `APIRouter` (with a prefix), affecting both per-request path attribution and the `paths` reported at startup.

## Changes (`apitally/starlette.py`)

- **`get_route_path`**: prefer the resolved route context FastAPI now stores in the request scope (`scope["fastapi"]["effective_route_context"].path`), falling back to the existing `app.routes` walk for plain Starlette apps.
- **`_get_routes`**: expand `_IncludedRouter` entries via `effective_route_contexts()`, reusing the pre-built `starlette_route` when available and only synthesizing a plain `Route` for `APIRoute` contexts. This correctly handles `Mount`, `Host`, and websocket routes (previously mis-handled) while keeping Starlette's `SchemaGenerator` happy.
- **`_get_startup_data`**: guard endpoint extraction in `try/except` so a failure can't crash app startup; log the traceback via `get_logger`.

## Verification

- `tests/test_starlette.py` — 14 passed (incl. `test_get_startup_data` asserting 8 paths, and request-path resolution for `/api/foo`, `/api/foo/{bar}`, `/api/bar`, `/api/baz`)
- `tests/test_fastapi.py` — 1 passed
- Tested locally with FastAPI 0.138.1 / Starlette 1.3.1 against an app combining top-level routes, an included router with a prefix, nested included routers, a websocket route, and a `Mount` — all endpoints and paths resolved correctly.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes route and path resolution for `fastapi` 0.138+ when using `include_router()`, restoring correct per-request path attribution and startup `paths`.

- **Bug Fixes**
  - `get_route_path`: use `scope["fastapi"]["effective_route_context"].path` when available; fallback to walking `app.routes` for plain `starlette`.
  - `_get_routes`: expand included routers via `effective_route_contexts()`, reuse `starlette_route` or synthesize a `Route` for `APIRoute`. Properly handles `Mount`, `Host`, and websocket routes while keeping `SchemaGenerator` intact.
  - `_get_startup_data`: guard endpoint extraction with try/except and log errors to avoid startup crashes.

- **Dependencies**
  - Update `fastapi` to `0.138.1` in `uv.lock`.

<sup>Written for commit 3519df665ef4c49ebd420a7201cc24dce3866b8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/apitally/apitally-py/pull/307?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

