### PR TITLE
Fix status_code=0 in request logs on unhandled exceptions

### DIFF
--- a/apitally/starlette.py
+++ b/apitally/starlette.py
@@ -220,9 +220,10 @@ class ApitallyMiddleware:
             consumer_identifier = consumer.identifier if consumer else None
             self.client.consumer_registry.add_or_update_consumer(consumer)
 
+            if response_status == 0 and exception is not None:
+                response_status = 500
+
             if path is not None:
-                if response_status == 0 and exception is not None:
-                    response_status = 500
                 self.client.request_counter.add_request(
                     consumer=consumer_identifier,
                     method=request.method,


### PR DESCRIPTION
## Problem

Logfire reported a spike of server-side validation errors:

```
{'errors': [{'type': 'greater_than_equal', 'loc': ('response', 'status_code'),
  'msg': 'Input should be greater than or equal to 100', 'input': 0, 'ctx': {'ge': 100}}]}
```

i.e. request logs were being sent with `response.status_code = 0`.

## Root cause

When a route raises an **unhandled** exception, Starlette's `ServerErrorMiddleware` (which sits _outside_ Apitally) generates the 500 response and sends it via the raw ASGI `send` callable — bypassing Apitally's `send_wrapper`. So `response_status` stayed at its initial value of `0`.

The code already had a correction for this, but it was nested inside `if path is not None:`, while the **request logger runs regardless of `path`**. On FastAPI 0.138+ included-router routes (where path resolution failed before #307), the correction was skipped, so the logger emitted `status_code=0`.

This was reproducible on `main` (pre-#307): any unhandled exception on a route under an `include_router()` produced `logged_status=0`.

## Fix

Move the correction out of the path-guarded block so it runs unconditionally before the logger and request counter are called:

```python
if response_status == 0 and exception is not None:
    response_status = 500

if path is not None:
    self.client.request_counter.add_request(...)
    ...
```

This decouples status-code correctness from path resolution.

## Verification

Reproduced before / after with a FastAPI app whose included router raises `ValueError`:

| Scenario | before | after |
|---|---|---|
| included router GET /api/boom -> 500 | logged_status=0 | logged_status=500 |
| included router GET /api/ok -> 200 | 200 | 200 |
| top-level GET /boom -> 500 | 500 | 500 |
| unknown GET /api/nonexistent -> 404 | 404 | 404 |

`tests/test_starlette.py` + `tests/test_fastapi.py` — 15 passed.

## Other frameworks

Audited all framework middlewares (Flask, Django, BlackSheep, Litestar). None can emit `status_code=0`:

- **BlackSheep**: `response.status if response else 500` — defaults to 500.
- **Django**: reads `response.status_code` directly; Django always produces a response object.
- **Flask**: Flask's patched `handle_exception` always calls `start_response` with 500.
- **Litestar**: shares Starlette's ASGI shape but guards with `if response_status < 100: return` (silently drops the request rather than reporting `0`).

So the fix is Starlette-only.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes request logs showing status_code=0 on unhandled exceptions in `Starlette`/`FastAPI` by recording 500 even when path resolution fails. Prevents validation errors and keeps request metrics accurate.

- **Bug Fixes**
  - Moved the 0→500 correction outside the `path` guard so it runs before logging and counting.
  - Verified: unhandled exceptions now log 500; other responses unchanged.

<sup>Written for commit 5a422c1e11bb43ddd3c75e6b0b4c01e89346f6a2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/apitally/apitally-py/pull/310?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

