### PR TITLE
Move redaction and body processing off the request thread

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,28 @@
+## Naming and wording conventions
+
+### General rules
+
+- Use plain, precise English. No invented shorthand, metaphors, or informal jargon (past offenders: "wire final", "hoist path", "smuggle", "plumbing", "canary").
+- A word qualifies only by referring to an actual thing in this codebase or its dependencies, never by sounding technical: "deferred export" (the `defer_export`/`finish_export` methods), "SERVER span" (OTel `SpanKind.SERVER`), "transport middleware" (the `Apitally*Middleware` classes).
+- Prefer a longer clear name over a compact clever one.
+- Vague verbs need an object or a from/to: not `resolve` but `resolve_value`.
+
+### Tests
+
+- A test name states the observable behavior it pins, readable without the test body: `test_no_response_size_when_client_stops_reading_mid_stream`, `test_request_body_not_read_for_disallowed_content_type`, `test_span_export_waits_for_streaming_response_to_complete`.
+- Name the behavior, not the mechanism or an internal codename.
+- Tests pinning the same scenario in different framework integrations share the same name.
+
+### Functions and methods
+
+- Boolean predicates read as questions: `is_`/`should_` prefixes (`should_skip_activation`, `is_sampled_in`, `is_not_self_log`). Never name a predicate as an imperative command.
+- The name states what the function actually does, including its outcome: a function that only logs a warning is `warn_if_sampler_drops_spans`, not `check_sampler`. A method that may discard or buffer as well as export is `process_ended_span`, not `export_span`.
+- One concept, one name across modules: the content-type allowlist check is `is_allowed_content_type` everywhere. Names align with the config option they implement (`_get_django_view_paths` for `include_django_views`).
+- When renaming a function, rename its associated constants to match (`is_contrib_receive_send_span` took `RECEIVE_SEND_NAME_SUFFIXES` and `CONTRIB_SCOPE_PREFIX` with it).
+- Public API names (`init_apitally`, `set_consumer`, `capture_exception`, `instrument_*`) are stable; naming improvements are internal only.
+
+## Comments and docstrings
+
+- A comment states something the code cannot: a constraint, an external system's behavior, or the reason for a choice. Name the real component (the env var, the thread, the framework version behavior), never a metaphor.
+- No historical references: nothing about the 0.x SDK, "previously", or "ported from". Comments describe the present code only.
+- A comment must sit next to the code it justifies and stay accurate about what that code covers.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@
 - Boolean predicates read as questions: `is_`/`should_` prefixes (`should_skip_activation`, `is_sampled_in`, `is_not_self_log`). Never name a predicate as an imperative command.
 - The name states what the function actually does, including its outcome: a function that only logs a warning is `warn_if_sampler_drops_spans`, not `check_sampler`. A method that may discard or buffer as well as export is `process_ended_span`, not `export_span`.
 - One concept, one name across modules: the content-type allowlist check is `is_allowed_content_type` everywhere. Names align with the config option they implement (`_get_django_view_paths` for `include_django_views`).
-- When renaming a function, rename its associated constants to match (`is_contrib_receive_send_span` took `RECEIVE_SEND_NAME_SUFFIXES` and `CONTRIB_SCOPE_PREFIX` with it).
+- When renaming a function, rename its associated constants to match.
 - Public API names (`init_apitally`, `set_consumer`, `capture_exception`, `instrument_*`) are stable; naming improvements are internal only.
 
 ## Comments and docstrings

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -112,7 +112,9 @@ Sampling decisions are deterministic per trace ID, so services sampling at the s
 
 ## Masking request and response bodies
 
-`mask_request_body_callback` and `mask_response_body_callback` are renamed to `mask_request_body` and `mask_response_body`. They no longer receive request/response dicts; the new signature is `(span, body: bytes) -> bytes | None`, where `span` is the request's SERVER span. Returning `None` replaces the captured body with `[REDACTED]`.
+`mask_request_body_callback` and `mask_response_body_callback` are renamed to `mask_request_body` and `mask_response_body`. They no longer receive request/response dicts; the new signature is `(span, body: bytes) -> bytes | None`, where `span` is the request's ended SERVER span. Returning `None` replaces the captured body with `[REDACTED]`.
+
+The callbacks run on a background export thread after the response has completed, so they must not rely on request-scoped state such as context variables or framework request globals. Everything needed for the masking decision is available on the `span` argument. Keep the callbacks fast: a slow callback delays the export of all telemetry, not just the request being masked.
 
 ```python
 def mask_request_body(span, body):

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -85,7 +85,7 @@ The `exclude_callback(request, response)` callback is replaced by request sampli
 
 - `sample_rate` sets the static fraction of requests captured as traces with their logs (default `1.0`).
 - `sample_on_request` refines it per request at span start. Nothing about a sampled-out request is ever transmitted, and capture work such as body buffering and masking is skipped (for Flask, request bodies are still buffered because the sampling decision happens later), making this (and `sample_rate`) the lever for volume and overhead. Returning `None` falls back to `sample_rate`.
-- `sample_on_response` decides at span end, so it can see the response status and any attributes you set via `set_request_attribute(...)`. It is quota-safe: the SDK holds a request's spans and logs in memory until this decision (up to 1,000 of each per request), so a request dropped here transmits nothing and consumes no quota. Capture work still runs for such requests — use request-stage sampling to skip that overhead. Returning `None` leaves the request-stage decision standing. It also cannot rescue a request already dropped at the request stage: the overall capture probability is the minimum of the two stages, so a response-stage boost like the example below only applies to requests that survived `sample_rate` / `sample_on_request`.
+- `sample_on_response` decides at span end, so it can see the response status and any attributes you set via `set_request_attribute(...)`. It is quota-safe: the SDK holds a request's spans and logs in memory until this decision (up to 1,000 of each per request), so a request dropped here transmits nothing and consumes no quota. Capture work still runs for such requests — use request-stage sampling to skip that overhead. Returning `None` leaves the request-stage decision standing. It also cannot rescue a request already dropped at the request stage: the overall capture probability is the minimum of the two stages, so a response-stage boost like the example below only applies to requests that survived `sample_rate` / `sample_on_request`. Captured headers and bodies are not on the span at this point (they are attached during export), so the sampling decision cannot depend on them.
 
 Both callbacks operate on the OpenTelemetry attributes of the request's SERVER span:
 
@@ -114,7 +114,7 @@ Sampling decisions are deterministic per trace ID, so services sampling at the s
 
 `mask_request_body_callback` and `mask_response_body_callback` are renamed to `mask_request_body` and `mask_response_body`. They no longer receive request/response dicts; the new signature is `(span, body: bytes) -> bytes | None`, where `span` is the request's ended SERVER span. Returning `None` replaces the captured body with `[REDACTED]`.
 
-The callbacks run on a background export thread after the response has completed, so they must not rely on request-scoped state such as context variables or framework request globals. Everything needed for the masking decision is available on the `span` argument. Keep the callbacks fast: a slow callback delays the export of all telemetry, not just the request being masked.
+The callbacks run on a background export thread after the response has completed, so they must not rely on request-scoped state such as context variables or framework request globals. Everything needed for the masking decision is available on the `span` argument; captured headers appear on it with redaction already applied. Keep the callbacks fast: a slow callback delays the export of all telemetry, not just the request being masked.
 
 ```python
 def mask_request_body(span, body):
@@ -130,6 +130,7 @@ If your application already has an OpenTelemetry `TracerProvider` configured (e.
 - The order of `init_apitally(...)` and your other OpenTelemetry setup does not matter, as long as your `TracerProvider` is registered before the application starts serving requests. A provider registered after startup is not picked up.
 - Your sampler applies. If it drops requests (e.g. `TraceIdRatioBased`), request logs in Apitally follow your sampling rate; Apitally's own `sample_rate` applies on top, to the requests your sampler keeps. Metrics are recorded independently of sampling and stay complete.
 - Your span attribute limits apply. A limit below 65,536 (e.g. via `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`) can truncate captured request/response bodies. The SDK logs a warning when it detects this.
+- Headers and bodies captured by Apitally never appear on the spans your own exporters receive. They are attached, already redacted, only on Apitally's export path. Headers captured by OpenTelemetry instrumentation itself (e.g. via `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST`) remain visible to your pipeline as usual.
 
 ## Version floors
 

--- a/apitally/django.py
+++ b/apitally/django.py
@@ -196,10 +196,10 @@ class ApitallyDjangoMiddleware(CaptureMixin):
             if config.log_response_headers:
                 self.set_header_attributes(span, "http.response.header.", response.items())
             response_body = self.capture_response_body(response, config, response_size, streaming)
-            if isinstance(request_body, str):
-                span.set_attribute("apitally.request.body", request_body)
-            if isinstance(response_body, str):
-                span.set_attribute("apitally.response.body", response_body)
+            if request_body is BODY_TOO_LARGE:
+                span.set_attribute("apitally.request.body", BODY_TOO_LARGE)
+            if response_body is BODY_TOO_LARGE:
+                span.set_attribute("apitally.response.body", BODY_TOO_LARGE)
             stash_request = request_body if isinstance(request_body, bytes) else None
             stash_response = response_body if isinstance(response_body, bytes) else None
             if (stash_request is not None or stash_response is not None) and span.context is not None:
@@ -271,9 +271,9 @@ class ApitallyDjangoMiddleware(CaptureMixin):
                         extra["http.response.body.size"] = response_size
                     # An abandoned iterator leaves a partial buffer; never export a truncated body
                     if completed and body is not None:
-                        if isinstance(body, str):
-                            extra["apitally.response.body"] = body
-                        elif processor is not None and span_id is not None:
+                        if body is BODY_TOO_LARGE:
+                            extra["apitally.response.body"] = BODY_TOO_LARGE
+                        elif isinstance(body, bytearray) and processor is not None and span_id is not None:
                             # The deferred export guarantees process_ended_span still runs and attaches this body
                             processor.stash_bodies(span_id, response_body=bytes(body))
                     if processor is not None and span_id is not None:

--- a/apitally/django.py
+++ b/apitally/django.py
@@ -305,7 +305,7 @@ class ApitallyDjangoMiddleware(CaptureMixin):
         return None  # pragma: no cover
 
 
-@lru_cache(256)
+@lru_cache(1024)
 def _regex_to_route_template(path: str) -> str:
     return PATH_PARAMETER_RE.sub(r"{\g<parameter>}", simplify_regex(path))
 

--- a/apitally/django.py
+++ b/apitally/django.py
@@ -24,9 +24,8 @@ from apitally.shared import activation, config, metrics, startup
 from apitally.shared.capture import BODY_TOO_LARGE, MAX_BODY_SIZE, CaptureMixin, is_allowed_content_type
 from apitally.shared.config import ApitallyConfig
 from apitally.shared.consumer import get_consumer_identifier, reset_consumer
-from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import get_server_span, get_server_span_processor, is_server_span_kept
-from apitally.shared.wsgi import parse_content_length
+from apitally.shared.wsgi import group_headers, parse_content_length
 
 
 if TYPE_CHECKING:
@@ -191,21 +190,27 @@ class ApitallyDjangoMiddleware(CaptureMixin):
                 span.set_attribute("http.request.body.size", request_size)
             if response_size is not None:
                 span.set_attribute("http.response.body.size", response_size)
-            if config.log_request_headers:
-                self.set_header_attributes(span, "http.request.header.", request.headers.items())
-            if config.log_response_headers:
-                self.set_header_attributes(span, "http.response.header.", response.items())
             response_body = self.capture_response_body(response, config, response_size, streaming)
             if request_body is BODY_TOO_LARGE:
                 span.set_attribute("apitally.request.body", BODY_TOO_LARGE)
             if response_body is BODY_TOO_LARGE:
                 span.set_attribute("apitally.response.body", BODY_TOO_LARGE)
-            stash_request = request_body if isinstance(request_body, bytes) else None
-            stash_response = response_body if isinstance(response_body, bytes) else None
-            if (stash_request is not None or stash_response is not None) and span.context is not None:
+            stash_request_headers = group_headers(request.headers.items()) if config.log_request_headers else None
+            stash_response_headers = group_headers(response.items()) if config.log_response_headers else None
+            stash_request_body = request_body if isinstance(request_body, bytes) else None
+            stash_response_body = response_body if isinstance(response_body, bytes) else None
+            if (
+                stash_request_headers or stash_request_body or stash_response_headers or stash_response_body
+            ) and span.context is not None:
                 processor = get_server_span_processor()
                 if processor is not None:
-                    processor.stash_bodies(span.context.span_id, stash_request, stash_response)
+                    processor.update_stash(
+                        span.context.span_id,
+                        request_headers=stash_request_headers,
+                        request_body=stash_request_body,
+                        response_headers=stash_response_headers,
+                        response_body=stash_response_body,
+                    )
         if streaming and response_size is None and not getattr(response, "is_async", False):
             self.finalize_streaming(
                 request, cast("StreamingHttpResponse", response), config, start_time, request_size, route, span
@@ -275,7 +280,7 @@ class ApitallyDjangoMiddleware(CaptureMixin):
                             extra["apitally.response.body"] = BODY_TOO_LARGE
                         elif isinstance(body, bytearray) and processor is not None and span_id is not None:
                             # The deferred export guarantees process_ended_span still runs and attaches this body
-                            processor.stash_bodies(span_id, response_body=bytes(body))
+                            processor.update_stash(span_id, response_body=bytes(body))
                     if processor is not None and span_id is not None:
                         processor.finish_export(span_id, extra or None)
                     metrics.record_request(
@@ -298,12 +303,6 @@ class ApitallyDjangoMiddleware(CaptureMixin):
         if match is not None and match.route:
             return _regex_to_route_template(match.route)
         return None  # pragma: no cover
-
-    def set_header_attributes(self, span: Span, prefix: str, headers: Iterable[tuple[str, str]]) -> None:
-        for name, value in headers:
-            name = name.lower()
-            values = [REDACTED] if self.redaction.should_redact_header(name) else [value]
-            span.set_attribute(prefix + name, values)
 
 
 @lru_cache(256)

--- a/apitally/django.py
+++ b/apitally/django.py
@@ -195,15 +195,17 @@ class ApitallyDjangoMiddleware(CaptureMixin):
                 self.set_header_attributes(span, "http.request.header.", request.headers.items())
             if config.log_response_headers:
                 self.set_header_attributes(span, "http.response.header.", response.items())
-            if request_body is not None:
-                self.set_body_attribute(
-                    span, "apitally.request.body", request_body, config.mask_request_body, "mask_request_body"
-                )
             response_body = self.capture_response_body(response, config, response_size, streaming)
-            if response_body is not None:
-                self.set_body_attribute(
-                    span, "apitally.response.body", response_body, config.mask_response_body, "mask_response_body"
-                )
+            if isinstance(request_body, str):
+                span.set_attribute("apitally.request.body", request_body)
+            if isinstance(response_body, str):
+                span.set_attribute("apitally.response.body", response_body)
+            stash_request = request_body if isinstance(request_body, bytes) else None
+            stash_response = response_body if isinstance(response_body, bytes) else None
+            if (stash_request is not None or stash_response is not None) and span.context is not None:
+                processor = get_server_span_processor()
+                if processor is not None:
+                    processor.stash_bodies(span.context.span_id, stash_request, stash_response)
         if streaming and response_size is None and not getattr(response, "is_async", False):
             self.finalize_streaming(
                 request, cast("StreamingHttpResponse", response), config, start_time, request_size, route, span
@@ -268,13 +270,12 @@ class ApitallyDjangoMiddleware(CaptureMixin):
                     if response_size is not None:
                         extra["http.response.body.size"] = response_size
                     # An abandoned iterator leaves a partial buffer; never export a truncated body
-                    if completed and body is not None and span is not None:
-                        extra["apitally.response.body"] = self.process_body(
-                            span,
-                            bytes(body) if isinstance(body, bytearray) else body,
-                            config.mask_response_body,
-                            "mask_response_body",
-                        )
+                    if completed and body is not None:
+                        if isinstance(body, str):
+                            extra["apitally.response.body"] = body
+                        elif processor is not None and span_id is not None:
+                            # The deferred export guarantees process_ended_span still runs and attaches this body
+                            processor.stash_bodies(span_id, response_body=bytes(body))
                     if processor is not None and span_id is not None:
                         processor.finish_export(span_id, extra or None)
                     metrics.record_request(

--- a/apitally/shared/activation.py
+++ b/apitally/shared/activation.py
@@ -162,7 +162,7 @@ def start_pipelines() -> None:
         span_processor.pending.clear()
         span_processor.deferred.clear()
         span_processor.held.clear()
-        span_processor.bodies.clear()
+        span_processor.stash.clear()
         span_processor.downstream = create_batch_span_processor(env)
     else:
         span_processor = ApitallySpanProcessor(create_batch_span_processor(env))

--- a/apitally/shared/activation.py
+++ b/apitally/shared/activation.py
@@ -15,6 +15,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
 from apitally.shared import config, metrics, providers, sentry
 from apitally.shared.config import TRUE_VALUES, ApitallyConfig
+from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.log_processor import ApitallyLogRecordProcessor, install_root_handler, uninstall_root_handler
 from apitally.shared.span_processor import ApitallySpanProcessor
 
@@ -157,9 +158,9 @@ def start_pipelines() -> None:
         span_processor.pending.clear()
         span_processor.deferred.clear()
         span_processor.held.clear()
-        span_processor.downstream = BatchSpanProcessor(providers.create_span_exporter(env))
+        span_processor.downstream = BatchSpanProcessor(ApitallySpanExporter(providers.create_span_exporter(env)))
     else:
-        span_processor = ApitallySpanProcessor(BatchSpanProcessor(providers.create_span_exporter(env)))
+        span_processor = ApitallySpanProcessor(BatchSpanProcessor(ApitallySpanExporter(providers.create_span_exporter(env))))
         if user_provider is not None:
             providers.attach_to_tracer_provider(user_provider, span_processor)
         else:
@@ -197,7 +198,7 @@ def after_fork_in_parent() -> None:
         if not activated or env is None:  # pragma: no cover
             return
         if span_processor is not None:
-            span_processor.downstream = BatchSpanProcessor(providers.create_span_exporter(env))
+            span_processor.downstream = BatchSpanProcessor(ApitallySpanExporter(providers.create_span_exporter(env)))
         if log_processor is not None:
             log_processor.downstream = BatchLogRecordProcessor(providers.create_log_exporter(env))
         metrics.attach_reader(env)

--- a/apitally/shared/activation.py
+++ b/apitally/shared/activation.py
@@ -141,6 +141,10 @@ def should_skip_activation() -> bool:
     )
 
 
+def create_batch_span_processor(env: str) -> BatchSpanProcessor:
+    return BatchSpanProcessor(ApitallySpanExporter(providers.create_span_exporter(env)))
+
+
 def start_pipelines() -> None:
     global env, resource, span_processor, log_processor, logger_provider, inherited_span_processor
     user_provider = providers.get_user_tracer_provider()
@@ -158,9 +162,10 @@ def start_pipelines() -> None:
         span_processor.pending.clear()
         span_processor.deferred.clear()
         span_processor.held.clear()
-        span_processor.downstream = BatchSpanProcessor(ApitallySpanExporter(providers.create_span_exporter(env)))
+        span_processor.bodies.clear()
+        span_processor.downstream = create_batch_span_processor(env)
     else:
-        span_processor = ApitallySpanProcessor(BatchSpanProcessor(ApitallySpanExporter(providers.create_span_exporter(env))))
+        span_processor = ApitallySpanProcessor(create_batch_span_processor(env))
         if user_provider is not None:
             providers.attach_to_tracer_provider(user_provider, span_processor)
         else:
@@ -198,7 +203,7 @@ def after_fork_in_parent() -> None:
         if not activated or env is None:  # pragma: no cover
             return
         if span_processor is not None:
-            span_processor.downstream = BatchSpanProcessor(ApitallySpanExporter(providers.create_span_exporter(env)))
+            span_processor.downstream = create_batch_span_processor(env)
         if log_processor is not None:
             log_processor.downstream = BatchLogRecordProcessor(providers.create_log_exporter(env))
         metrics.attach_reader(env)

--- a/apitally/shared/activation.py
+++ b/apitally/shared/activation.py
@@ -38,7 +38,7 @@ span_processor: ApitallySpanProcessor | None = None
 log_processor: ApitallyLogRecordProcessor | None = None
 logger_provider: LoggerProvider | None = None
 
-# OTel's own fork handlers hold weak references to batch processors; keep quiesced
+# OTel's own fork handlers hold weak references to batch processors; keep shut-down
 # instances alive so a later fork never calls a dead reference
 retired_processors: list[SpanProcessor | LogRecordProcessor] = []
 
@@ -179,7 +179,7 @@ def start_pipelines() -> None:
 
 
 def before_fork() -> None:
-    """Quiesce so the process owns no threads at the instant of fork."""
+    """Stop all SDK-owned threads so none are running at the instant of fork."""
     # Held across the fork so an in-flight activate completes first; released in both after
     # handlers (the child gets a fresh lock, since an inherited locked mutex would deadlock)
     activation_lock.acquire()
@@ -194,7 +194,7 @@ def before_fork() -> None:
             retired_processors.append(log_processor.downstream)
             log_processor.downstream.shutdown()
     except Exception:  # pragma: no cover
-        logger.exception("Error quiescing Apitally before fork")
+        logger.exception("Error stopping Apitally threads before fork")
 
 
 def after_fork_in_parent() -> None:

--- a/apitally/shared/asgi.py
+++ b/apitally/shared/asgi.py
@@ -3,12 +3,9 @@ import time
 from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
-from opentelemetry.sdk.trace import Span
-
 from apitally.shared import metrics
 from apitally.shared.capture import ALLOWED_CONTENT_TYPES, BODY_TOO_LARGE, MAX_BODY_SIZE, CaptureMixin
 from apitally.shared.consumer import get_consumer_identifier, reset_consumer
-from apitally.shared.redaction import REDACTED, Redaction
 from apitally.shared.span_processor import get_server_span, get_server_span_processor, is_server_span_kept
 
 
@@ -21,16 +18,11 @@ Send = Callable[[Message], Awaitable[None]]
 ASGIApp = Callable[[Scope, Receive, Send], Awaitable[None]]
 
 
-def set_header_attributes(
-    span: Span, prefix: str, headers: Iterable[tuple[bytes, bytes]], redaction: Redaction
-) -> None:
+def group_headers(headers: Iterable[tuple[bytes, bytes]]) -> dict[str, list[str]]:
     grouped: dict[str, list[str]] = {}
     for name, value in headers:
         grouped.setdefault(name.decode("latin-1").lower(), []).append(value.decode("latin-1"))
-    for name, values in grouped.items():
-        if redaction.should_redact_header(name):
-            values = [REDACTED]
-        span.set_attribute(prefix + name, values)
+    return grouped
 
 
 class ApitallyASGIMiddleware(CaptureMixin):
@@ -63,6 +55,7 @@ class ApitallyASGIMiddleware(CaptureMixin):
         response_started = False
         response_size: int | None = None
         response_size_counter = 0
+        response_headers: list[tuple[bytes, bytes]] | None = None
         response_body = bytearray()
         response_body_complete = False
         response_too_large = False
@@ -123,8 +116,6 @@ class ApitallyASGIMiddleware(CaptureMixin):
                     route = root_path[len(initial_root_path) :] + route
             span = get_server_span()
             if is_server_span_kept() and span is not None and span.is_recording():
-                if config.log_request_headers:
-                    set_header_attributes(span, "http.request.header.", request_headers, self.redaction)
                 if route:
                     # Overwrites the instrumentor's raw route so spans and metrics agree on the template
                     span.set_attribute("http.route", route)
@@ -138,20 +129,30 @@ class ApitallyASGIMiddleware(CaptureMixin):
                     span.set_attribute("apitally.request.body", BODY_TOO_LARGE)
                 if response_too_large:
                     span.set_attribute("apitally.response.body", BODY_TOO_LARGE)
-                stash_request = (
+                stash_request_headers = group_headers(request_headers) if config.log_request_headers else None
+                stash_response_headers = group_headers(response_headers) if response_headers is not None else None
+                stash_request_body = (
                     bytes(request_body)
                     if capture_request and not request_too_large and request_body and request_body_complete
                     else None
                 )
-                stash_response = (
+                stash_response_body = (
                     bytes(response_body)
                     if capture_response and not response_too_large and response_body and response_body_complete
                     else None
                 )
-                if (stash_request is not None or stash_response is not None) and span.context is not None:
+                if (
+                    stash_request_headers or stash_request_body or stash_response_headers or stash_response_body
+                ) and span.context is not None:
                     processor = get_server_span_processor()
                     if processor is not None:
-                        processor.stash_bodies(span.context.span_id, stash_request, stash_response)
+                        processor.update_stash(
+                            span.context.span_id,
+                            request_headers=stash_request_headers,
+                            request_body=stash_request_body,
+                            response_headers=stash_response_headers,
+                            response_body=stash_response_body,
+                        )
             metrics.record_request(
                 method=scope.get("method", ""),
                 route=route or "",
@@ -164,28 +165,27 @@ class ApitallyASGIMiddleware(CaptureMixin):
             )
 
         async def send_wrapper(message: Message) -> None:
-            nonlocal status, response_started, response_size, response_size_counter
+            nonlocal status, response_started, response_size, response_size_counter, response_headers
             nonlocal response_body, response_body_complete, response_too_large, capture_response
             try:
                 if message["type"] == "http.response.start":
                     response_started = True
                     status = message["status"]
-                    response_headers = message.get("headers") or []
-                    content_length = parse_int(get_header(response_headers, b"content-length"))
-                    if content_length is not None and get_header(response_headers, b"transfer-encoding") != b"chunked":
+                    headers = message.get("headers") or []
+                    content_length = parse_int(get_header(headers, b"content-length"))
+                    if content_length is not None and get_header(headers, b"transfer-encoding") != b"chunked":
                         response_size = content_length
                     kept = is_server_span_kept()
                     capture_response = (
                         kept
                         and config.log_response_body
-                        and is_allowed_content_type(get_header(response_headers, b"content-type"))
+                        and is_allowed_content_type(get_header(headers, b"content-type"))
                     )
                     response_too_large = (
                         capture_response and response_size is not None and response_size > MAX_BODY_SIZE
                     )
-                    span = get_server_span()
-                    if kept and config.log_response_headers and span is not None and span.is_recording():
-                        set_header_attributes(span, "http.response.header.", response_headers, self.redaction)
+                    if kept and config.log_response_headers:
+                        response_headers = headers
                 elif message["type"] == "http.response.body":
                     body = message.get("body", b"")
                     response_size_counter += len(body)

--- a/apitally/shared/asgi.py
+++ b/apitally/shared/asgi.py
@@ -9,7 +9,7 @@ from apitally.shared import metrics
 from apitally.shared.capture import ALLOWED_CONTENT_TYPES, BODY_TOO_LARGE, MAX_BODY_SIZE, CaptureMixin
 from apitally.shared.consumer import get_consumer_identifier, reset_consumer
 from apitally.shared.redaction import REDACTED, Redaction
-from apitally.shared.span_processor import get_server_span, is_server_span_kept
+from apitally.shared.span_processor import get_server_span, get_server_span_processor, is_server_span_kept
 
 
 logger = logging.getLogger(__name__)
@@ -136,24 +136,22 @@ class ApitallyASGIMiddleware(CaptureMixin):
                 # Partial buffers from aborted requests/responses are never exported
                 if request_too_large:
                     span.set_attribute("apitally.request.body", BODY_TOO_LARGE)
-                elif capture_request and request_body and request_body_complete:
-                    self.set_body_attribute(
-                        span,
-                        "apitally.request.body",
-                        bytes(request_body),
-                        config.mask_request_body,
-                        "mask_request_body",
-                    )
                 if response_too_large:
                     span.set_attribute("apitally.response.body", BODY_TOO_LARGE)
-                elif capture_response and response_body and response_body_complete:
-                    self.set_body_attribute(
-                        span,
-                        "apitally.response.body",
-                        bytes(response_body),
-                        config.mask_response_body,
-                        "mask_response_body",
-                    )
+                stash_request = (
+                    bytes(request_body)
+                    if capture_request and not request_too_large and request_body and request_body_complete
+                    else None
+                )
+                stash_response = (
+                    bytes(response_body)
+                    if capture_response and not response_too_large and response_body and response_body_complete
+                    else None
+                )
+                if (stash_request is not None or stash_response is not None) and span.context is not None:
+                    processor = get_server_span_processor()
+                    if processor is not None:
+                        processor.stash_bodies(span.context.span_id, stash_request, stash_response)
             metrics.record_request(
                 method=scope.get("method", ""),
                 route=route or "",

--- a/apitally/shared/capture.py
+++ b/apitally/shared/capture.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 from apitally.shared.config import ApitallyConfig, get_config
-from apitally.shared.redaction import Redaction
 
 
 MAX_BODY_SIZE = 50_000
@@ -22,13 +21,9 @@ def is_allowed_content_type(content_type: str | None) -> bool:
 
 
 class CaptureMixin:
-    """Config and redaction binding shared by the transport middlewares and the span exporter."""
+    """Config binding shared by the transport middlewares."""
 
     config: ApitallyConfig
-    redaction: Redaction
 
     def bind_config(self) -> None:
         self.config = get_config() or ApitallyConfig()
-        self.redaction = Redaction(
-            self.config.mask_query_params, self.config.mask_headers, self.config.mask_body_fields
-        )

--- a/apitally/shared/capture.py
+++ b/apitally/shared/capture.py
@@ -1,19 +1,8 @@
 from __future__ import annotations
 
-import json
-import logging
-from collections.abc import Callable
-from typing import TYPE_CHECKING
-
 from apitally.shared.config import ApitallyConfig, get_config
-from apitally.shared.redaction import REDACTED, Redaction
+from apitally.shared.redaction import Redaction
 
-
-if TYPE_CHECKING:
-    from opentelemetry.sdk.trace import ReadableSpan, Span
-
-
-logger = logging.getLogger(__name__)
 
 MAX_BODY_SIZE = 50_000
 BODY_TOO_LARGE = "[BODY_TOO_LARGE]"
@@ -33,7 +22,7 @@ def is_allowed_content_type(content_type: str | None) -> bool:
 
 
 class CaptureMixin:
-    """Config binding and redaction-aware body attribute writing shared by the transport middlewares."""
+    """Config and redaction binding shared by the transport middlewares and the span exporter."""
 
     config: ApitallyConfig
     redaction: Redaction
@@ -43,49 +32,3 @@ class CaptureMixin:
         self.redaction = Redaction(
             self.config.mask_query_params, self.config.mask_headers, self.config.mask_body_fields
         )
-
-    def set_body_attribute(
-        self,
-        span: Span,
-        key: str,
-        body: bytes | str,
-        mask_callback: Callable[[ReadableSpan, bytes], bytes | None] | None,
-        callback_name: str,
-    ) -> None:
-        span.set_attribute(key, self.process_body(span, body, mask_callback, callback_name))
-
-    def process_body(
-        self,
-        span: ReadableSpan,
-        body: bytes | str,
-        mask_callback: Callable[[ReadableSpan, bytes], bytes | None] | None,
-        callback_name: str,
-    ) -> str:
-        if isinstance(body, str):
-            return body
-        if mask_callback is not None:
-            try:
-                masked = mask_callback(span, body)
-            except Exception:
-                logger.warning(
-                    "Apitally %s callback raised an exception, body replaced with %s",
-                    callback_name,
-                    REDACTED,
-                    exc_info=True,
-                )
-                masked = None
-            if masked is None:
-                return REDACTED
-            if len(masked) > MAX_BODY_SIZE:
-                return BODY_TOO_LARGE
-            body = masked
-        try:
-            data = json.loads(body)
-        except Exception:
-            # Non-JSON but allowlisted (e.g. text/plain): stored as-is
-            return body.decode("utf-8", errors="replace")
-        try:
-            return json.dumps(self.redaction.redact_body(data), separators=(",", ":"), ensure_ascii=False)
-        except Exception:
-            logger.warning("Error redacting body, replaced with %s", REDACTED, exc_info=True)
-            return REDACTED

--- a/apitally/shared/exporter.py
+++ b/apitally/shared/exporter.py
@@ -1,12 +1,13 @@
+import json
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
-from apitally.shared.config import ApitallyConfig, get_config
-from apitally.shared.redaction import REDACTED, Redaction
-from apitally.shared.span_processor import copy_span_with_attributes
+from apitally.shared.capture import BODY_TOO_LARGE, MAX_BODY_SIZE, CaptureMixin
+from apitally.shared.redaction import REDACTED
+from apitally.shared.span_processor import BODIES_ATTRIBUTE, copy_span_with_attributes
 
 
 logger = logging.getLogger(__name__)
@@ -15,15 +16,12 @@ QUERY_ATTRIBUTES = ("url.query", "http.target", "http.url", "url.full")
 HEADER_ATTRIBUTE_PREFIXES = ("http.request.header.", "http.response.header.")
 
 
-class ApitallySpanExporter(SpanExporter):
-    """Applies redaction on the export thread, in front of the delegate exporter."""
+class ApitallySpanExporter(SpanExporter, CaptureMixin):
+    """Applies redaction and body processing on the export thread, in front of the delegate exporter."""
 
     def __init__(self, delegate: SpanExporter) -> None:
         self.delegate = delegate
-        self.config = get_config() or ApitallyConfig()
-        self.redaction = Redaction(
-            self.config.mask_query_params, self.config.mask_headers, self.config.mask_body_fields
-        )
+        self.bind_config()
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         processed = []
@@ -36,8 +34,11 @@ class ApitallySpanExporter(SpanExporter):
         return self.delegate.export(processed)
 
     def process_span(self, span: ReadableSpan) -> ReadableSpan:
-        """Return a redacted copy when redaction is needed. The original span is never mutated."""
-        if not any(
+        """Return a copy with redaction applied and body attributes added. The copy does not
+        carry the raw bodies, and the original span is never mutated."""
+        request_body, response_body = getattr(span, BODIES_ATTRIBUTE, (None, None))
+        has_bodies = request_body is not None or response_body is not None
+        if not has_bodies and not any(
             key in QUERY_ATTRIBUTES or key.startswith(HEADER_ATTRIBUTE_PREFIXES) for key in span.attributes or {}
         ):
             return span
@@ -56,7 +57,56 @@ class ApitallySpanExporter(SpanExporter):
             if redacted != value:
                 attributes[key] = redacted
                 changed = True
+        if request_body is not None:
+            attributes["apitally.request.body"] = self.process_body(
+                span, request_body, self.config.mask_request_body, "mask_request_body"
+            )
+            changed = True
+        if response_body is not None:
+            attributes["apitally.response.body"] = self.process_body(
+                span, response_body, self.config.mask_response_body, "mask_response_body"
+            )
+            changed = True
         return copy_span_with_attributes(span, attributes) if changed else span
+
+    def process_body(
+        self,
+        span: ReadableSpan,
+        body: bytes,
+        mask_callback: Callable[[ReadableSpan, bytes], bytes | None] | None,
+        callback_name: str,
+    ) -> str:
+        if mask_callback is not None:
+            try:
+                masked = mask_callback(span, body)
+            except Exception:
+                logger.warning(
+                    "Apitally %s callback raised an exception, body replaced with %s",
+                    callback_name,
+                    REDACTED,
+                    exc_info=True,
+                )
+                masked = None
+            if masked is None:
+                return REDACTED
+            if not isinstance(masked, bytes):
+                logger.warning(
+                    "Apitally %s callback returned an invalid value, body replaced with %s", callback_name, REDACTED
+                )
+                return REDACTED
+            if len(masked) > MAX_BODY_SIZE:
+                return BODY_TOO_LARGE
+            body = masked
+        try:
+            data = json.loads(body)
+        except Exception:
+            # Non-JSON but allowlisted (e.g. text/plain): stored as-is
+            return body.decode("utf-8", errors="replace")
+        try:
+            return json.dumps(self.redaction.redact_body(data), separators=(",", ":"), ensure_ascii=False)
+        except Exception:
+            logger.warning("Error redacting body, replaced with %s", REDACTED, exc_info=True)
+            return REDACTED
 
     def shutdown(self) -> None:
         self.delegate.shutdown()

--- a/apitally/shared/exporter.py
+++ b/apitally/shared/exporter.py
@@ -33,7 +33,7 @@ class ApitallySpanExporter(SpanExporter):
         for span in spans:
             try:
                 processed.append(self.process_span(span))
-            except Exception:
+            except Exception:  # pragma: no cover
                 # A span that failed redaction must never leave the process
                 logger.exception("Error processing span for export, span dropped")
         return self.delegate.export(processed)
@@ -104,7 +104,7 @@ class ApitallySpanExporter(SpanExporter):
                 masked = None
             if masked is None:
                 return REDACTED
-            if not isinstance(masked, bytes):
+            if not isinstance(masked, bytes):  # pragma: no cover
                 logger.warning(
                     "Apitally %s callback returned an invalid value, body replaced with %s", callback_name, REDACTED
                 )
@@ -119,12 +119,12 @@ class ApitallySpanExporter(SpanExporter):
             return body.decode("utf-8", errors="replace")
         try:
             return json.dumps(self.redaction.redact_body(data), separators=(",", ":"), ensure_ascii=False)
-        except Exception:
+        except Exception:  # pragma: no cover
             logger.warning("Error redacting body, replaced with %s", REDACTED, exc_info=True)
             return REDACTED
 
     def shutdown(self) -> None:
         self.delegate.shutdown()
 
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
+    def force_flush(self, timeout_millis: int = 30000) -> bool:  # pragma: no cover
         return self.delegate.force_flush(timeout_millis)

--- a/apitally/shared/exporter.py
+++ b/apitally/shared/exporter.py
@@ -5,9 +5,10 @@ from collections.abc import Callable, Sequence
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 
-from apitally.shared.capture import BODY_TOO_LARGE, MAX_BODY_SIZE, CaptureMixin
-from apitally.shared.redaction import REDACTED
-from apitally.shared.span_processor import BODIES_ATTRIBUTE, copy_span_with_attributes
+from apitally.shared.capture import BODY_TOO_LARGE, MAX_BODY_SIZE
+from apitally.shared.config import ApitallyConfig, get_config
+from apitally.shared.redaction import REDACTED, Redaction
+from apitally.shared.span_processor import STASH_ATTRIBUTE, RequestStash, copy_span_with_attributes
 
 
 logger = logging.getLogger(__name__)
@@ -16,12 +17,16 @@ QUERY_ATTRIBUTES = ("url.query", "http.target", "http.url", "url.full")
 HEADER_ATTRIBUTE_PREFIXES = ("http.request.header.", "http.response.header.")
 
 
-class ApitallySpanExporter(SpanExporter, CaptureMixin):
-    """Applies redaction and body processing on the export thread, in front of the delegate exporter."""
+class ApitallySpanExporter(SpanExporter):
+    """Applies redaction and attaches stashed headers and bodies on the export thread,
+    in front of the delegate exporter."""
 
     def __init__(self, delegate: SpanExporter) -> None:
         self.delegate = delegate
-        self.bind_config()
+        self.config = get_config() or ApitallyConfig()
+        self.redaction = Redaction(
+            self.config.mask_query_params, self.config.mask_headers, self.config.mask_body_fields
+        )
 
     def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
         processed = []
@@ -34,11 +39,10 @@ class ApitallySpanExporter(SpanExporter, CaptureMixin):
         return self.delegate.export(processed)
 
     def process_span(self, span: ReadableSpan) -> ReadableSpan:
-        """Return a copy with redaction applied and body attributes added. The copy does not
-        carry the raw bodies, and the original span is never mutated."""
-        request_body, response_body = getattr(span, BODIES_ATTRIBUTE, (None, None))
-        has_bodies = request_body is not None or response_body is not None
-        if not has_bodies and not any(
+        """Return a copy with redaction applied and stashed headers and bodies added as attributes.
+        The copy does not carry the stash, and the original span is never mutated."""
+        stash: RequestStash | None = getattr(span, STASH_ATTRIBUTE, None)
+        if stash is None and not any(
             key in QUERY_ATTRIBUTES or key.startswith(HEADER_ATTRIBUTE_PREFIXES) for key in span.attributes or {}
         ):
             return span
@@ -57,17 +61,28 @@ class ApitallySpanExporter(SpanExporter, CaptureMixin):
             if redacted != value:
                 attributes[key] = redacted
                 changed = True
-        if request_body is not None:
+        if stash is None:
+            return copy_span_with_attributes(span, attributes) if changed else span
+        for prefix, headers in (
+            ("http.request.header.", stash.request_headers),
+            ("http.response.header.", stash.response_headers),
+        ):
+            if headers:
+                for name, values in self.redaction.redact_headers(headers).items():
+                    attributes[prefix + name] = values
+        # The mask callbacks receive the span as it will be exported, minus the body attributes
+        span = copy_span_with_attributes(span, dict(attributes))
+        if stash.request_body is None and stash.response_body is None:
+            return span
+        if stash.request_body is not None:
             attributes["apitally.request.body"] = self.process_body(
-                span, request_body, self.config.mask_request_body, "mask_request_body"
+                span, stash.request_body, self.config.mask_request_body, "mask_request_body"
             )
-            changed = True
-        if response_body is not None:
+        if stash.response_body is not None:
             attributes["apitally.response.body"] = self.process_body(
-                span, response_body, self.config.mask_response_body, "mask_response_body"
+                span, stash.response_body, self.config.mask_response_body, "mask_response_body"
             )
-            changed = True
-        return copy_span_with_attributes(span, attributes) if changed else span
+        return copy_span_with_attributes(span, attributes)
 
     def process_body(
         self,

--- a/apitally/shared/exporter.py
+++ b/apitally/shared/exporter.py
@@ -1,0 +1,65 @@
+import logging
+from collections.abc import Sequence
+
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+
+from apitally.shared.config import ApitallyConfig, get_config
+from apitally.shared.redaction import REDACTED, Redaction
+from apitally.shared.span_processor import copy_span_with_attributes
+
+
+logger = logging.getLogger(__name__)
+
+QUERY_ATTRIBUTES = ("url.query", "http.target", "http.url", "url.full")
+HEADER_ATTRIBUTE_PREFIXES = ("http.request.header.", "http.response.header.")
+
+
+class ApitallySpanExporter(SpanExporter):
+    """Applies redaction on the export thread, in front of the delegate exporter."""
+
+    def __init__(self, delegate: SpanExporter) -> None:
+        self.delegate = delegate
+        self.config = get_config() or ApitallyConfig()
+        self.redaction = Redaction(
+            self.config.mask_query_params, self.config.mask_headers, self.config.mask_body_fields
+        )
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        processed = []
+        for span in spans:
+            try:
+                processed.append(self.process_span(span))
+            except Exception:
+                # A span that failed redaction must never leave the process
+                logger.exception("Error processing span for export, span dropped")
+        return self.delegate.export(processed)
+
+    def process_span(self, span: ReadableSpan) -> ReadableSpan:
+        """Return a redacted copy when redaction is needed. The original span is never mutated."""
+        if not any(
+            key in QUERY_ATTRIBUTES or key.startswith(HEADER_ATTRIBUTE_PREFIXES) for key in span.attributes or {}
+        ):
+            return span
+        attributes = dict(span.attributes or {})
+        changed = False
+        for key, value in attributes.items():
+            if key in QUERY_ATTRIBUTES and isinstance(value, str):
+                redacted = self.redaction.redact_query_params(value, assume_query=key == "url.query")
+            elif key.startswith(HEADER_ATTRIBUTE_PREFIXES):
+                header = key.removeprefix("http.request.header.").removeprefix("http.response.header.")
+                if not self.redaction.should_redact_header(header):
+                    continue
+                redacted = REDACTED if isinstance(value, str) else [REDACTED]
+            else:
+                continue
+            if redacted != value:
+                attributes[key] = redacted
+                changed = True
+        return copy_span_with_attributes(span, attributes) if changed else span
+
+    def shutdown(self) -> None:
+        self.delegate.shutdown()
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return self.delegate.force_flush(timeout_millis)

--- a/apitally/shared/redaction.py
+++ b/apitally/shared/redaction.py
@@ -55,7 +55,7 @@ class Redaction:
             base, query = "", value
         # Treat legacy semicolon separators as pair boundaries too, so those values are also redacted
         pairs = parse_qsl(query.replace(";", "&"), keep_blank_values=True)
-        redacted = urlencode([(k, REDACTED if matches_any(self.query_param_patterns, k) else v) for k, v in pairs])
+        redacted = urlencode([(k, REDACTED if self.should_redact_query_param(k) else v) for k, v in pairs])
         return f"{base}?{redacted}" if sep else redacted
 
     def redact_headers(self, headers: Mapping[str, str | list[str]]) -> dict[str, str | list[str]]:
@@ -69,7 +69,7 @@ class Redaction:
     def redact_body(self, data: JSONValue) -> JSONValue:
         if isinstance(data, dict):
             return {
-                k: REDACTED if isinstance(v, str) and matches_any(self.body_field_patterns, k) else self.redact_body(v)
+                k: REDACTED if isinstance(v, str) and self.should_redact_body_field(k) else self.redact_body(v)
                 for k, v in data.items()
             }
         if isinstance(data, list):
@@ -80,6 +80,14 @@ class Redaction:
     def should_redact_header(self, name: str) -> bool:
         # Also match the underscore-normalized attribute key form emitted by older instrumentors
         return matches_any(self.header_patterns, name) or matches_any(self.header_patterns, name.replace("_", "-"))
+
+    @lru_cache(maxsize=1024)
+    def should_redact_query_param(self, name: str) -> bool:
+        return matches_any(self.query_param_patterns, name)
+
+    @lru_cache(maxsize=1024)
+    def should_redact_body_field(self, name: str) -> bool:
+        return matches_any(self.body_field_patterns, name)
 
 
 def compile_patterns(patterns: list[str]) -> list[re.Pattern[str]]:

--- a/apitally/shared/span_processor.py
+++ b/apitally/shared/span_processor.py
@@ -1,6 +1,7 @@
 import logging
 from collections.abc import Callable, Mapping
 from contextvars import ContextVar
+from dataclasses import dataclass
 from functools import lru_cache
 
 from opentelemetry.context import Context
@@ -46,8 +47,19 @@ EXCLUDE_USER_AGENT_PATTERN = combine_patterns(
 RECEIVE_SEND_NAME_SUFFIXES = (" http send", " http receive", " websocket send", " websocket receive")
 CONTRIB_SCOPE_PREFIX = "opentelemetry.instrumentation."
 MAX_BUFFERED_SPANS = 1_000
-MAX_STASHED_BODIES = 2_048
-BODIES_ATTRIBUTE = "_apitally_bodies"
+MAX_STASHED_REQUESTS = 2_048
+STASH_ATTRIBUTE = "_apitally_stash"
+
+
+@dataclass(slots=True)
+class RequestStash:
+    """Headers and bodies captured by a transport for one request, held until the SERVER span is exported."""
+
+    request_headers: dict[str, list[str]] | None = None
+    request_body: bytes | None = None
+    response_headers: dict[str, list[str]] | None = None
+    response_body: bytes | None = None
+
 
 server_span_var: ContextVar[Span | None] = ContextVar("apitally_server_span", default=None)
 server_span_kept_var: ContextVar[bool] = ContextVar("apitally_server_span_kept", default=False)
@@ -84,7 +96,7 @@ class ApitallySpanProcessor(SpanProcessor):
         self.pending: dict[int, list[ReadableSpan]] = {}
         self.deferred: set[int] = set()
         self.held: dict[int, ReadableSpan] = {}
-        self.bodies: dict[int, tuple[bytes | None, bytes | None]] = {}
+        self.stash: dict[int, RequestStash] = {}
         # Assigned by the log processor so both buffers flush or discard on the same decision
         self.on_request_finished: Callable[[int, bool], None] | None = None
         self.config = get_config() or ApitallyConfig()
@@ -160,16 +172,30 @@ class ApitallySpanProcessor(SpanProcessor):
         except Exception:  # pragma: no cover
             logger.exception("Error in Apitally span processor")
 
-    def stash_bodies(self, span_id: int, request_body: bytes | None = None, response_body: bytes | None = None) -> None:
-        """Hold raw bodies until process_ended_span attaches them to the exported SERVER span snapshot."""
-        existing = self.bodies.get(span_id)
-        if existing is not None:
-            request_body = request_body if request_body is not None else existing[0]
-            response_body = response_body if response_body is not None else existing[1]
-        elif len(self.bodies) >= MAX_STASHED_BODIES:
-            self.bodies.pop(next(iter(self.bodies)))
-            logger.debug("Apitally body stash cap reached, dropping oldest entry")
-        self.bodies[span_id] = (request_body, response_body)
+    def update_stash(
+        self,
+        span_id: int,
+        request_headers: dict[str, list[str]] | None = None,
+        request_body: bytes | None = None,
+        response_headers: dict[str, list[str]] | None = None,
+        response_body: bytes | None = None,
+    ) -> None:
+        """Hold captured headers and bodies until process_ended_span attaches them to the exported
+        SERVER span snapshot. Fields already stashed for the span are kept unless a new value is given."""
+        entry = self.stash.get(span_id)
+        if entry is None:
+            if len(self.stash) >= MAX_STASHED_REQUESTS:
+                self.stash.pop(next(iter(self.stash)))
+                logger.debug("Apitally request stash cap reached, dropping oldest entry")
+            entry = self.stash[span_id] = RequestStash()
+        if request_headers is not None:
+            entry.request_headers = request_headers
+        if request_body is not None:
+            entry.request_body = request_body
+        if response_headers is not None:
+            entry.response_headers = response_headers
+        if response_body is not None:
+            entry.response_body = response_body
 
     def process_ended_span(self, span: ReadableSpan, context: SpanContext) -> None:
         keep, server_span_id = self.spans.pop(context.span_id, (False, None))
@@ -178,16 +204,16 @@ class ApitallySpanProcessor(SpanProcessor):
         buffer = self.pending.pop(context.span_id, None)
         if buffer is not None:
             # Pending SERVER root: the response-stage decision flushes or discards the whole request
-            bodies = self.bodies.pop(context.span_id, None)
+            stash = self.stash.pop(context.span_id, None)
             response_kept = self.sample_response(span, context.trace_id)
             if response_kept:
                 for buffered_span in buffer:
                     self.downstream.on_end(buffered_span)
-                if bodies is not None:
+                if stash is not None:
                     # A private copy, because user-attached processors receive the same shared snapshot.
-                    # If the batch queue drops the span, the bodies are freed with it.
+                    # If the batch queue drops the span, the stash is freed with it.
                     span = copy_span_with_attributes(span, dict(span.attributes or {}))
-                    setattr(span, BODIES_ATTRIBUTE, bodies)
+                    setattr(span, STASH_ATTRIBUTE, stash)
                 self.downstream.on_end(span)
             else:
                 # Mark the request's still-open spans as dropped so telemetry arriving later is discarded
@@ -218,7 +244,7 @@ class ApitallySpanProcessor(SpanProcessor):
         self.deferred.clear()
         # Pending requests' SERVER spans can never export after shutdown, so their telemetry is unreachable
         self.pending.clear()
-        self.bodies.clear()
+        self.stash.clear()
         self.downstream.shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:

--- a/apitally/shared/span_processor.py
+++ b/apitally/shared/span_processor.py
@@ -160,9 +160,7 @@ class ApitallySpanProcessor(SpanProcessor):
         except Exception:  # pragma: no cover
             logger.exception("Error in Apitally span processor")
 
-    def stash_bodies(
-        self, span_id: int, request_body: bytes | None = None, response_body: bytes | None = None
-    ) -> None:
+    def stash_bodies(self, span_id: int, request_body: bytes | None = None, response_body: bytes | None = None) -> None:
         """Hold raw bodies until process_ended_span attaches them to the exported SERVER span snapshot."""
         existing = self.bodies.get(span_id)
         if existing is not None:

--- a/apitally/shared/span_processor.py
+++ b/apitally/shared/span_processor.py
@@ -10,7 +10,7 @@ from opentelemetry.trace import SpanContext, SpanKind
 from opentelemetry.util.types import AttributeValue
 
 from apitally.shared.config import ApitallyConfig, get_config
-from apitally.shared.redaction import REDACTED, Redaction, combine_patterns, compile_patterns, matches_any
+from apitally.shared.redaction import combine_patterns, compile_patterns, matches_any
 
 
 logger = logging.getLogger(__name__)
@@ -43,8 +43,6 @@ EXCLUDE_USER_AGENT_PATTERN = combine_patterns(
     ]
 )
 
-QUERY_ATTRIBUTES = ("url.query", "http.target", "http.url", "url.full")
-HEADER_ATTRIBUTE_PREFIXES = ("http.request.header.", "http.response.header.")
 RECEIVE_SEND_NAME_SUFFIXES = (" http send", " http receive", " websocket send", " websocket receive")
 CONTRIB_SCOPE_PREFIX = "opentelemetry.instrumentation."
 MAX_BUFFERED_SPANS = 1_000
@@ -89,9 +87,6 @@ class ApitallySpanProcessor(SpanProcessor):
         self.config = get_config() or ApitallyConfig()
         self.sample_rate_bound = TraceIdRatioBased.get_bound_for_rate(self.config.sample_rate)
         self.exclude_path_patterns = compile_patterns(self.config.exclude_paths)
-        self.redaction = Redaction(
-            self.config.mask_query_params, self.config.mask_headers, self.config.mask_body_fields
-        )
 
     def on_start(self, span: Span, parent_context: Context | None = None) -> None:
         try:
@@ -172,8 +167,8 @@ class ApitallySpanProcessor(SpanProcessor):
             response_kept = self.sample_response(span, context.trace_id)
             if response_kept:
                 for buffered_span in buffer:
-                    self.downstream.on_end(self.redact_span(buffered_span))
-                self.downstream.on_end(self.redact_span(span))
+                    self.downstream.on_end(buffered_span)
+                self.downstream.on_end(span)
             else:
                 # Mark the request's still-open spans as dropped so telemetry arriving later is discarded
                 for span_id, entry in list(self.spans.items()):
@@ -189,7 +184,7 @@ class ApitallySpanProcessor(SpanProcessor):
             else:
                 logger.debug("Apitally span buffer cap reached for request, dropping span")
             return
-        self.downstream.on_end(self.redact_span(span))
+        self.downstream.on_end(span)
 
     def resolve_server_span_id(self, span_id: int) -> int | None:
         """Return the SERVER span id for an in-flight span, or None if the request is dropped."""
@@ -259,29 +254,6 @@ class ApitallySpanProcessor(SpanProcessor):
             return float(result)
         logger.warning("Apitally %s callback returned an invalid value, request captured: %r", name, result)
         return 1.0
-
-    def redact_span(self, span: ReadableSpan) -> ReadableSpan:
-        """Return a redacted copy when redaction is needed. The original span is never mutated."""
-        if not any(
-            key in QUERY_ATTRIBUTES or key.startswith(HEADER_ATTRIBUTE_PREFIXES) for key in span.attributes or {}
-        ):
-            return span
-        attributes = dict(span.attributes or {})
-        changed = False
-        for key, value in attributes.items():
-            if key in QUERY_ATTRIBUTES and isinstance(value, str):
-                redacted = self.redaction.redact_query_params(value, assume_query=key == "url.query")
-            elif key.startswith(HEADER_ATTRIBUTE_PREFIXES):
-                header = key.removeprefix("http.request.header.").removeprefix("http.response.header.")
-                if not self.redaction.should_redact_header(header):
-                    continue
-                redacted = REDACTED if isinstance(value, str) else [REDACTED]
-            else:
-                continue
-            if redacted != value:
-                attributes[key] = redacted
-                changed = True
-        return copy_span_with_attributes(span, attributes) if changed else span
 
 
 def copy_span_with_attributes(span: ReadableSpan, attributes: dict[str, AttributeValue]) -> ReadableSpan:

--- a/apitally/shared/span_processor.py
+++ b/apitally/shared/span_processor.py
@@ -46,6 +46,8 @@ EXCLUDE_USER_AGENT_PATTERN = combine_patterns(
 RECEIVE_SEND_NAME_SUFFIXES = (" http send", " http receive", " websocket send", " websocket receive")
 CONTRIB_SCOPE_PREFIX = "opentelemetry.instrumentation."
 MAX_BUFFERED_SPANS = 1_000
+MAX_STASHED_BODIES = 2_048
+BODIES_ATTRIBUTE = "_apitally_bodies"
 
 server_span_var: ContextVar[Span | None] = ContextVar("apitally_server_span", default=None)
 server_span_kept_var: ContextVar[bool] = ContextVar("apitally_server_span_kept", default=False)
@@ -82,6 +84,7 @@ class ApitallySpanProcessor(SpanProcessor):
         self.pending: dict[int, list[ReadableSpan]] = {}
         self.deferred: set[int] = set()
         self.held: dict[int, ReadableSpan] = {}
+        self.bodies: dict[int, tuple[bytes | None, bytes | None]] = {}
         # Assigned by the log processor so both buffers flush or discard on the same decision
         self.on_request_finished: Callable[[int, bool], None] | None = None
         self.config = get_config() or ApitallyConfig()
@@ -157,6 +160,19 @@ class ApitallySpanProcessor(SpanProcessor):
         except Exception:  # pragma: no cover
             logger.exception("Error in Apitally span processor")
 
+    def stash_bodies(
+        self, span_id: int, request_body: bytes | None = None, response_body: bytes | None = None
+    ) -> None:
+        """Hold raw bodies until process_ended_span attaches them to the exported SERVER span snapshot."""
+        existing = self.bodies.get(span_id)
+        if existing is not None:
+            request_body = request_body if request_body is not None else existing[0]
+            response_body = response_body if response_body is not None else existing[1]
+        elif len(self.bodies) >= MAX_STASHED_BODIES:
+            self.bodies.pop(next(iter(self.bodies)))
+            logger.debug("Apitally body stash cap reached, dropping oldest entry")
+        self.bodies[span_id] = (request_body, response_body)
+
     def process_ended_span(self, span: ReadableSpan, context: SpanContext) -> None:
         keep, server_span_id = self.spans.pop(context.span_id, (False, None))
         if not keep:
@@ -164,10 +180,16 @@ class ApitallySpanProcessor(SpanProcessor):
         buffer = self.pending.pop(context.span_id, None)
         if buffer is not None:
             # Pending SERVER root: the response-stage decision flushes or discards the whole request
+            bodies = self.bodies.pop(context.span_id, None)
             response_kept = self.sample_response(span, context.trace_id)
             if response_kept:
                 for buffered_span in buffer:
                     self.downstream.on_end(buffered_span)
+                if bodies is not None:
+                    # A private copy, because user-attached processors receive the same shared snapshot.
+                    # If the batch queue drops the span, the bodies are freed with it.
+                    span = copy_span_with_attributes(span, dict(span.attributes or {}))
+                    setattr(span, BODIES_ATTRIBUTE, bodies)
                 self.downstream.on_end(span)
             else:
                 # Mark the request's still-open spans as dropped so telemetry arriving later is discarded
@@ -198,6 +220,7 @@ class ApitallySpanProcessor(SpanProcessor):
         self.deferred.clear()
         # Pending requests' SERVER spans can never export after shutdown, so their telemetry is unreachable
         self.pending.clear()
+        self.bodies.clear()
         self.downstream.shutdown()
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:

--- a/apitally/shared/span_processor.py
+++ b/apitally/shared/span_processor.py
@@ -44,8 +44,6 @@ EXCLUDE_USER_AGENT_PATTERN = combine_patterns(
     ]
 )
 
-RECEIVE_SEND_NAME_SUFFIXES = (" http send", " http receive", " websocket send", " websocket receive")
-CONTRIB_SCOPE_PREFIX = "opentelemetry.instrumentation."
 MAX_BUFFERED_SPANS = 1_000
 MAX_STASHED_REQUESTS = 2_048
 STASH_ATTRIBUTE = "_apitally_stash"
@@ -323,7 +321,7 @@ def copy_span_with_attributes(span: ReadableSpan, attributes: dict[str, Attribut
 def is_contrib_receive_send_span(span: Span) -> bool:
     return (
         span.kind == SpanKind.INTERNAL
-        and span.name.endswith(RECEIVE_SEND_NAME_SUFFIXES)
+        and span.name.endswith((" http send", " http receive", " websocket send", " websocket receive"))
         and span.instrumentation_scope is not None
-        and span.instrumentation_scope.name.startswith(CONTRIB_SCOPE_PREFIX)
+        and span.instrumentation_scope.name.startswith("opentelemetry.instrumentation.")
     )

--- a/apitally/shared/span_processor.py
+++ b/apitally/shared/span_processor.py
@@ -184,7 +184,7 @@ class ApitallySpanProcessor(SpanProcessor):
         SERVER span snapshot. Fields already stashed for the span are kept unless a new value is given."""
         entry = self.stash.get(span_id)
         if entry is None:
-            if len(self.stash) >= MAX_STASHED_REQUESTS:
+            if len(self.stash) >= MAX_STASHED_REQUESTS:  # pragma: no cover
                 self.stash.pop(next(iter(self.stash)))
                 logger.debug("Apitally request stash cap reached, dropping oldest entry")
             entry = self.stash[span_id] = RequestStash()

--- a/apitally/shared/wsgi.py
+++ b/apitally/shared/wsgi.py
@@ -115,9 +115,9 @@ class ApitallyWSGIMiddleware(CaptureMixin):
                 span.set_attribute("http.request.body.size", state.request_size)
             if config.log_request_headers:
                 self.set_header_attributes(span, "http.request.header.", environ_headers(environ))
-            if isinstance(state.request_body, str):
-                span.set_attribute("apitally.request.body", state.request_body)
-            elif state.request_body is not None and processor is not None and span.context is not None:
+            if state.request_body is BODY_TOO_LARGE:
+                span.set_attribute("apitally.request.body", BODY_TOO_LARGE)
+            elif isinstance(state.request_body, bytes) and processor is not None and span.context is not None:
                 processor.stash_bodies(span.context.span_id, request_body=state.request_body)
         if config.log_response_headers:
             self.set_header_attributes(span, "http.response.header.", headers)
@@ -145,9 +145,9 @@ class ApitallyWSGIMiddleware(CaptureMixin):
                 if isinstance(body, bytearray):
                     # An abandoned iterable leaves a partial buffer; never export a truncated body
                     body = bytes(body) if state.completed else None
-                if isinstance(body, str):
-                    extra["apitally.response.body"] = body
-                elif body is not None and processor is not None and state.deferred_span_id is not None:
+                if body is BODY_TOO_LARGE:
+                    extra["apitally.response.body"] = BODY_TOO_LARGE
+                elif isinstance(body, bytes) and processor is not None and state.deferred_span_id is not None:
                     # The deferred export guarantees process_ended_span still runs and attaches this body
                     processor.stash_bodies(state.deferred_span_id, response_body=body)
             if state.deferred_span_id is not None and processor is not None:

--- a/apitally/shared/wsgi.py
+++ b/apitally/shared/wsgi.py
@@ -11,14 +11,12 @@ from apitally.shared import metrics
 from apitally.shared.capture import BODY_TOO_LARGE, MAX_BODY_SIZE, CaptureMixin, is_allowed_content_type
 from apitally.shared.config import ApitallyConfig
 from apitally.shared.consumer import get_consumer_identifier, reset_consumer
-from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import get_server_span, get_server_span_processor, is_server_span_kept
 
 
 if TYPE_CHECKING:
     from _typeshed import OptExcInfo
     from _typeshed.wsgi import StartResponse, WSGIApplication, WSGIEnvironment
-    from opentelemetry.sdk.trace import Span
 
 
 logger = logging.getLogger(__name__)
@@ -109,19 +107,27 @@ class ApitallyWSGIMiddleware(CaptureMixin):
         if not kept or span is None or not span.is_recording():
             return
         processor = get_server_span_processor()
+        stash_request_headers: dict[str, list[str]] | None = None
+        stash_request_body: bytes | None = None
         if not state.request_attributes_written:
             state.request_attributes_written = True
             if state.request_size is not None:
                 span.set_attribute("http.request.body.size", state.request_size)
-            if config.log_request_headers:
-                self.set_header_attributes(span, "http.request.header.", environ_headers(environ))
             if state.request_body is BODY_TOO_LARGE:
                 span.set_attribute("apitally.request.body", BODY_TOO_LARGE)
-            elif isinstance(state.request_body, bytes) and processor is not None and span.context is not None:
-                processor.stash_bodies(span.context.span_id, request_body=state.request_body)
-        if config.log_response_headers:
-            self.set_header_attributes(span, "http.response.header.", headers)
+            elif isinstance(state.request_body, bytes):
+                stash_request_body = state.request_body
+            if config.log_request_headers:
+                stash_request_headers = environ_headers(environ)
+        stash_response_headers = headers if config.log_response_headers else None
         if processor is not None and span.context is not None:
+            if stash_request_headers or stash_request_body or stash_response_headers:
+                processor.update_stash(
+                    span.context.span_id,
+                    request_headers=stash_request_headers,
+                    request_body=stash_request_body,
+                    response_headers=stash_response_headers,
+                )
             # The final response size is only known at finalize, which may run after the span has ended
             processor.defer_export(span.context.span_id)
             state.deferred_span_id = span.context.span_id
@@ -149,7 +155,7 @@ class ApitallyWSGIMiddleware(CaptureMixin):
                     extra["apitally.response.body"] = BODY_TOO_LARGE
                 elif isinstance(body, bytes) and processor is not None and state.deferred_span_id is not None:
                     # The deferred export guarantees process_ended_span still runs and attaches this body
-                    processor.stash_bodies(state.deferred_span_id, response_body=body)
+                    processor.update_stash(state.deferred_span_id, response_body=body)
             if state.deferred_span_id is not None and processor is not None:
                 processor.finish_export(state.deferred_span_id, extra or None)
             route = self.get_route(environ) if self.get_route is not None else None
@@ -165,12 +171,6 @@ class ApitallyWSGIMiddleware(CaptureMixin):
             )
         except Exception:  # pragma: no cover
             logger.exception("Error in Apitally WSGI middleware")
-
-    def set_header_attributes(self, span: Span, prefix: str, headers: dict[str, list[str]]) -> None:
-        for name, values in headers.items():
-            if self.redaction.should_redact_header(name):
-                values = [REDACTED]
-            span.set_attribute(prefix + name, values)
 
 
 class ResponseWrapper:
@@ -250,7 +250,7 @@ def environ_headers(environ: WSGIEnvironment) -> dict[str, list[str]]:
     return headers
 
 
-def group_headers(headers: list[tuple[str, str]]) -> dict[str, list[str]]:
+def group_headers(headers: Iterable[tuple[str, str]]) -> dict[str, list[str]]:
     grouped: dict[str, list[str]] = {}
     for name, value in headers:
         grouped.setdefault(name.lower(), []).append(value)

--- a/apitally/shared/wsgi.py
+++ b/apitally/shared/wsgi.py
@@ -108,19 +108,19 @@ class ApitallyWSGIMiddleware(CaptureMixin):
         span = get_server_span()
         if not kept or span is None or not span.is_recording():
             return
+        processor = get_server_span_processor()
         if not state.request_attributes_written:
             state.request_attributes_written = True
             if state.request_size is not None:
                 span.set_attribute("http.request.body.size", state.request_size)
             if config.log_request_headers:
                 self.set_header_attributes(span, "http.request.header.", environ_headers(environ))
-            if state.request_body is not None:
-                self.set_body_attribute(
-                    span, "apitally.request.body", state.request_body, config.mask_request_body, "mask_request_body"
-                )
+            if isinstance(state.request_body, str):
+                span.set_attribute("apitally.request.body", state.request_body)
+            elif state.request_body is not None and processor is not None and span.context is not None:
+                processor.stash_bodies(span.context.span_id, request_body=state.request_body)
         if config.log_response_headers:
             self.set_header_attributes(span, "http.response.header.", headers)
-        processor = get_server_span_processor()
         if processor is not None and span.context is not None:
             # The final response size is only known at finalize, which may run after the span has ended
             processor.defer_export(span.context.span_id)
@@ -139,19 +139,18 @@ class ApitallyWSGIMiddleware(CaptureMixin):
             extra: dict[str, str | int] = {}
             if state.response_size is not None:
                 extra["http.response.body.size"] = state.response_size
+            processor = get_server_span_processor() if state.deferred_span_id is not None else None
             if kept and span is not None and state.response_body is not None:
                 body = state.response_body
                 if isinstance(body, bytearray):
                     # An abandoned iterable leaves a partial buffer; never export a truncated body
                     body = bytes(body) if state.completed else None
-                if body is not None:
-                    extra["apitally.response.body"] = self.process_body(
-                        span,
-                        body,
-                        config.mask_response_body,
-                        "mask_response_body",
-                    )
-            if state.deferred_span_id is not None and (processor := get_server_span_processor()) is not None:
+                if isinstance(body, str):
+                    extra["apitally.response.body"] = body
+                elif body is not None and processor is not None and state.deferred_span_id is not None:
+                    # The deferred export guarantees process_ended_span still runs and attaches this body
+                    processor.stash_bodies(state.deferred_span_id, response_body=body)
+            if state.deferred_span_id is not None and processor is not None:
                 processor.finish_export(state.deferred_span_id, extra or None)
             route = self.get_route(environ) if self.get_route is not None else None
             metrics.record_request(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,7 @@ from opentelemetry.trace import SpanKind, Tracer
 
 from apitally.shared import activation, config, metrics, providers, startup
 from apitally.shared.consumer import consumer_holder_var
+from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.span_processor import (
     ApitallySpanProcessor,
     server_span_kept_var,
@@ -214,9 +215,9 @@ def startup_payload(exporters: InMemoryExporters) -> dict[str, Any]:
 
 
 def create_tracer(exporter: SpanExporter, sampler: Sampler = ALWAYS_ON, scope: str = CONTRIB_SCOPE) -> Tracer:
-    # The Apitally span processor binds config at construction, so build after configure()
+    # The Apitally span processor and exporter bind config at construction, so build after configure()
     provider = TracerProvider(sampler=sampler)
-    provider.add_span_processor(ApitallySpanProcessor(SimpleSpanProcessor(exporter)))
+    provider.add_span_processor(ApitallySpanProcessor(SimpleSpanProcessor(ApitallySpanExporter(exporter))))
     return provider.get_tracer(scope)
 
 

--- a/tests/shared/test_activation.py
+++ b/tests/shared/test_activation.py
@@ -177,7 +177,7 @@ def test_activation_attaches_to_existing_user_tracer_provider(
     assert span.name == "GET /items"
 
 
-def test_before_fork_quiesces_sdk_threads(exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch):
+def test_before_fork_stops_sdk_threads(exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch):
     threads_before = set(threading.enumerate())
     configure_and_activate(monkeypatch)
     started = [t for t in threading.enumerate() if t not in threads_before]

--- a/tests/shared/test_exporter.py
+++ b/tests/shared/test_exporter.py
@@ -1,0 +1,65 @@
+from urllib.parse import parse_qsl
+
+from opentelemetry.sdk.trace import Span as SDKSpan
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.trace import SpanKind
+
+from apitally.shared.exporter import ApitallySpanExporter
+from apitally.shared.redaction import REDACTED
+from tests.conftest import create_trace_pipeline, unwrap
+
+
+def test_forwarded_span_redacted_and_original_unmutated():
+    tracer, exporter = create_trace_pipeline()
+    attributes = {
+        "url.query": "token=secret123&page=2",
+        "http.target": "/items?token=secret123&page=2",
+        "http.url": "https://example.com/items?token=secret123&page=2",
+        "http.request.header.authorization": ("Bearer secret123",),
+        "http.request.header.x_api_key": ("secret123",),
+        "http.response.header.set-cookie": ("session=abc",),
+        "http.response.header.content-type": ("application/json",),
+    }
+    with tracer.start_as_current_span("GET /items", kind=SpanKind.SERVER, attributes=attributes) as span:
+        pass
+    assert isinstance(span, SDKSpan)
+
+    (exported,) = exporter.get_finished_spans()
+    assert dict(parse_qsl(str(unwrap(exported.attributes)["url.query"]))) == {"token": REDACTED, "page": "2"}
+    assert dict(parse_qsl(str(unwrap(exported.attributes)["http.target"]).partition("?")[2])) == {
+        "token": REDACTED,
+        "page": "2",
+    }
+    assert "secret123" not in str(unwrap(exported.attributes)["http.url"])
+    assert unwrap(exported.attributes)["http.request.header.authorization"] == [REDACTED]
+    assert unwrap(exported.attributes)["http.request.header.x_api_key"] == [REDACTED]
+    assert unwrap(exported.attributes)["http.response.header.set-cookie"] == [REDACTED]
+    assert unwrap(exported.attributes)["http.response.header.content-type"] == ("application/json",)
+
+    assert unwrap(span.attributes)["url.query"] == "token=secret123&page=2"
+    assert unwrap(span.attributes)["http.request.header.authorization"] == ("Bearer secret123",)
+
+
+def test_client_span_url_full_redacted():
+    tracer, exporter = create_trace_pipeline()
+    with tracer.start_as_current_span("GET /items", kind=SpanKind.SERVER):
+        with tracer.start_as_current_span(
+            "GET", kind=SpanKind.CLIENT, attributes={"url.full": "https://x.example/v1?api-key=secret&ok=1"}
+        ):
+            pass
+    client = next(s for s in exporter.get_finished_spans() if s.kind == SpanKind.CLIENT)
+    url = str(unwrap(client.attributes)["url.full"])
+    assert url.startswith("https://x.example/v1?")
+    assert dict(parse_qsl(url.partition("?")[2])) == {"api-key": REDACTED, "ok": "1"}
+
+
+def test_span_without_sensitive_attributes_passes_through_unchanged():
+    tracer, exporter = create_trace_pipeline()
+    with tracer.start_as_current_span("GET /items", kind=SpanKind.SERVER, attributes={"url.path": "/items"}):
+        pass
+    (span,) = exporter.get_finished_spans()
+
+    delegate = InMemorySpanExporter()
+    ApitallySpanExporter(delegate).export([span])
+    (passed_through,) = delegate.get_finished_spans()
+    assert passed_through is span

--- a/tests/shared/test_exporter.py
+++ b/tests/shared/test_exporter.py
@@ -11,7 +11,7 @@ from opentelemetry.trace import SpanKind
 from apitally.shared.config import set_config
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.redaction import REDACTED
-from apitally.shared.span_processor import BODIES_ATTRIBUTE, ApitallySpanProcessor, get_server_span_processor
+from apitally.shared.span_processor import STASH_ATTRIBUTE, ApitallySpanProcessor, get_server_span_processor
 from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, create_trace_pipeline, unwrap
 
 
@@ -71,8 +71,8 @@ def test_span_without_sensitive_attributes_passes_through_unchanged():
     assert passed_through is span
 
 
-def test_user_attached_exporters_never_see_bodies():
-    set_config(write_token=WRITE_TOKEN, log_request_body=True)
+def test_user_attached_exporters_never_see_captured_headers_and_bodies():
+    set_config(write_token=WRITE_TOKEN, log_request_headers=True, log_request_body=True)
     user_exporter = InMemorySpanExporter()
     apitally_exporter = InMemorySpanExporter()
     provider = TracerProvider(sampler=ALWAYS_ON)
@@ -82,32 +82,47 @@ def test_user_attached_exporters_never_see_bodies():
 
     with tracer.start_as_current_span("POST /items", kind=SpanKind.SERVER) as span:
         processor = unwrap(get_server_span_processor())
-        processor.stash_bodies(span.get_span_context().span_id, request_body=b'{"password": "hunter2"}')
+        processor.update_stash(
+            span.get_span_context().span_id,
+            request_headers={"authorization": ["Bearer secret123"], "accept": ["application/json"]},
+            request_body=b'{"password": "hunter2"}',
+        )
 
     (apitally_span,) = apitally_exporter.get_finished_spans()
     assert json.loads(str(unwrap(apitally_span.attributes)["apitally.request.body"])) == {"password": REDACTED}
+    assert unwrap(apitally_span.attributes)["http.request.header.authorization"] == [REDACTED]
+    assert unwrap(apitally_span.attributes)["http.request.header.accept"] == ["application/json"]
 
     (user_span,) = user_exporter.get_finished_spans()
     attributes = dict(user_span.attributes or {})
     assert "apitally.request.body" not in attributes
+    assert not any(key.startswith("http.request.header.") for key in attributes)
     assert "hunter2" not in str(attributes)
-    assert not hasattr(user_span, BODIES_ATTRIBUTE)
+    assert "secret123" not in str(attributes)
+    assert not hasattr(user_span, STASH_ATTRIBUTE)
 
 
-def test_mask_callback_receives_ended_span():
+def test_mask_callback_receives_ended_span_with_redacted_headers():
     seen: list[ReadableSpan] = []
 
     def mask(span: ReadableSpan, body: bytes) -> bytes:
         seen.append(span)
         return body
 
-    set_config(write_token=WRITE_TOKEN, log_request_body=True, mask_request_body=mask)
+    set_config(write_token=WRITE_TOKEN, log_request_headers=True, log_request_body=True, mask_request_body=mask)
     tracer, exporter = create_trace_pipeline()
     with tracer.start_as_current_span("POST /items", kind=SpanKind.SERVER) as span:
         processor = unwrap(get_server_span_processor())
-        processor.stash_bodies(span.get_span_context().span_id, request_body=b'{"a": 1}')
+        processor.update_stash(
+            span.get_span_context().span_id,
+            request_headers={"authorization": ["Bearer secret123"], "content-type": ["application/json"]},
+            request_body=b'{"a": 1}',
+        )
 
     (exported,) = exporter.get_finished_spans()
     assert unwrap(exported.attributes)["apitally.request.body"] == '{"a":1}'
     (seen_span,) = seen
     assert seen_span.end_time is not None
+    assert unwrap(seen_span.attributes)["http.request.header.authorization"] == [REDACTED]
+    assert unwrap(seen_span.attributes)["http.request.header.content-type"] == ["application/json"]
+    assert not hasattr(seen_span, STASH_ATTRIBUTE)

--- a/tests/shared/test_exporter.py
+++ b/tests/shared/test_exporter.py
@@ -102,7 +102,7 @@ def test_user_attached_exporters_never_see_captured_headers_and_bodies():
     assert not hasattr(user_span, STASH_ATTRIBUTE)
 
 
-def test_mask_callback_receives_ended_span_with_redacted_headers():
+def test_mask_callback_receives_ended_span():
     seen: list[ReadableSpan] = []
 
     def mask(span: ReadableSpan, body: bytes) -> bytes:

--- a/tests/shared/test_exporter.py
+++ b/tests/shared/test_exporter.py
@@ -1,12 +1,18 @@
+import json
 from urllib.parse import parse_qsl
 
+from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace import Span as SDKSpan
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.trace import SpanKind
 
+from apitally.shared.config import set_config
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.redaction import REDACTED
-from tests.conftest import create_trace_pipeline, unwrap
+from apitally.shared.span_processor import BODIES_ATTRIBUTE, ApitallySpanProcessor, get_server_span_processor
+from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, create_trace_pipeline, unwrap
 
 
 def test_forwarded_span_redacted_and_original_unmutated():
@@ -63,3 +69,45 @@ def test_span_without_sensitive_attributes_passes_through_unchanged():
     ApitallySpanExporter(delegate).export([span])
     (passed_through,) = delegate.get_finished_spans()
     assert passed_through is span
+
+
+def test_user_attached_exporters_never_see_bodies():
+    set_config(write_token=WRITE_TOKEN, log_request_body=True)
+    user_exporter = InMemorySpanExporter()
+    apitally_exporter = InMemorySpanExporter()
+    provider = TracerProvider(sampler=ALWAYS_ON)
+    provider.add_span_processor(ApitallySpanProcessor(SimpleSpanProcessor(ApitallySpanExporter(apitally_exporter))))
+    provider.add_span_processor(SimpleSpanProcessor(user_exporter))
+    tracer = provider.get_tracer(CONTRIB_SCOPE)
+
+    with tracer.start_as_current_span("POST /items", kind=SpanKind.SERVER) as span:
+        processor = unwrap(get_server_span_processor())
+        processor.stash_bodies(span.get_span_context().span_id, request_body=b'{"password": "hunter2"}')
+
+    (apitally_span,) = apitally_exporter.get_finished_spans()
+    assert json.loads(str(unwrap(apitally_span.attributes)["apitally.request.body"])) == {"password": REDACTED}
+
+    (user_span,) = user_exporter.get_finished_spans()
+    attributes = dict(user_span.attributes or {})
+    assert "apitally.request.body" not in attributes
+    assert "hunter2" not in str(attributes)
+    assert not hasattr(user_span, BODIES_ATTRIBUTE)
+
+
+def test_mask_callback_receives_ended_span():
+    seen: list[ReadableSpan] = []
+
+    def mask(span: ReadableSpan, body: bytes) -> bytes:
+        seen.append(span)
+        return body
+
+    set_config(write_token=WRITE_TOKEN, log_request_body=True, mask_request_body=mask)
+    tracer, exporter = create_trace_pipeline()
+    with tracer.start_as_current_span("POST /items", kind=SpanKind.SERVER) as span:
+        processor = unwrap(get_server_span_processor())
+        processor.stash_bodies(span.get_span_context().span_id, request_body=b'{"a": 1}')
+
+    (exported,) = exporter.get_finished_spans()
+    assert unwrap(exported.attributes)["apitally.request.body"] == '{"a":1}'
+    (seen_span,) = seen
+    assert seen_span.end_time is not None

--- a/tests/shared/test_span_processor.py
+++ b/tests/shared/test_span_processor.py
@@ -1,11 +1,9 @@
 import contextvars
-from urllib.parse import parse_qsl
 
 import pytest
 from opentelemetry import trace
 from opentelemetry.context import Context
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
-from opentelemetry.sdk.trace import Span as SDKSpan
 from opentelemetry.sdk.trace.export import BatchSpanProcessor, SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON, TraceIdRatioBased
@@ -13,7 +11,6 @@ from opentelemetry.trace import NonRecordingSpan, SpanContext, SpanKind, TraceFl
 
 from apitally.shared.config import set_config
 from apitally.shared.consumer import get_consumer_identifier, reset_consumer, set_consumer
-from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import (
     MAX_BUFFERED_SPANS,
     ApitallySpanProcessor,
@@ -379,48 +376,6 @@ def test_contrib_send_receive_spans_dropped_user_spans_kept(
         with user_tracer.start_as_current_span("my http send"):
             pass
     assert {s.name for s in exporter.get_finished_spans()} == {"GET /items", "my http send"}
-
-
-def test_forwarded_span_redacted_and_original_unmutated(tracer: Tracer, exporter: InMemorySpanExporter):
-    attributes = {
-        "url.query": "token=secret123&page=2",
-        "http.target": "/items?token=secret123&page=2",
-        "http.url": "https://example.com/items?token=secret123&page=2",
-        "http.request.header.authorization": ("Bearer secret123",),
-        "http.request.header.x_api_key": ("secret123",),
-        "http.response.header.set-cookie": ("session=abc",),
-        "http.response.header.content-type": ("application/json",),
-    }
-    with tracer.start_as_current_span("GET /items", kind=SpanKind.SERVER, attributes=attributes) as span:
-        pass
-    assert isinstance(span, SDKSpan)
-
-    (exported,) = exporter.get_finished_spans()
-    assert dict(parse_qsl(str(unwrap(exported.attributes)["url.query"]))) == {"token": REDACTED, "page": "2"}
-    assert dict(parse_qsl(str(unwrap(exported.attributes)["http.target"]).partition("?")[2])) == {
-        "token": REDACTED,
-        "page": "2",
-    }
-    assert "secret123" not in str(unwrap(exported.attributes)["http.url"])
-    assert unwrap(exported.attributes)["http.request.header.authorization"] == [REDACTED]
-    assert unwrap(exported.attributes)["http.request.header.x_api_key"] == [REDACTED]
-    assert unwrap(exported.attributes)["http.response.header.set-cookie"] == [REDACTED]
-    assert unwrap(exported.attributes)["http.response.header.content-type"] == ("application/json",)
-
-    assert unwrap(span.attributes)["url.query"] == "token=secret123&page=2"
-    assert unwrap(span.attributes)["http.request.header.authorization"] == ("Bearer secret123",)
-
-
-def test_client_span_url_full_redacted(tracer: Tracer, exporter: InMemorySpanExporter):
-    with tracer.start_as_current_span("GET /items", kind=SpanKind.SERVER):
-        with tracer.start_as_current_span(
-            "GET", kind=SpanKind.CLIENT, attributes={"url.full": "https://x.example/v1?api-key=secret&ok=1"}
-        ):
-            pass
-    client = next(s for s in exporter.get_finished_spans() if s.kind == SpanKind.CLIENT)
-    url = str(unwrap(client.attributes)["url.full"])
-    assert url.startswith("https://x.example/v1?")
-    assert dict(parse_qsl(url.partition("?")[2])) == {"api-key": REDACTED, "ok": "1"}
 
 
 def test_context_var_resolves_server_span_inside_request_only(tracer: Tracer):

--- a/tests/shared/test_span_processor.py
+++ b/tests/shared/test_span_processor.py
@@ -218,6 +218,19 @@ def test_sample_on_response_keeps_errors_drops_healthy(exporter: InMemorySpanExp
     assert [s.name for s in exporter.get_finished_spans()] == ["child", "GET /b"]
 
 
+def test_sampled_out_response_releases_stashed_bodies(exporter: InMemorySpanExporter):
+    set_config(write_token=WRITE_TOKEN, sample_on_response=lambda span: False)
+    processor = ApitallySpanProcessor(SimpleSpanProcessor(exporter))
+    provider = TracerProvider(sampler=ALWAYS_ON)
+    provider.add_span_processor(processor)
+    tracer = provider.get_tracer(CONTRIB_SCOPE)
+
+    with tracer.start_as_current_span("POST /items", kind=SpanKind.SERVER) as span:
+        processor.stash_bodies(span.get_span_context().span_id, request_body=b'{"a": 1}')
+    assert exporter.get_finished_spans() == ()
+    assert processor.bodies == {}
+
+
 def test_span_buffer_cap_bounds_kept_and_dropped_requests(exporter: InMemorySpanExporter):
     set_config(
         write_token=WRITE_TOKEN,

--- a/tests/shared/test_span_processor.py
+++ b/tests/shared/test_span_processor.py
@@ -218,7 +218,7 @@ def test_sample_on_response_keeps_errors_drops_healthy(exporter: InMemorySpanExp
     assert [s.name for s in exporter.get_finished_spans()] == ["child", "GET /b"]
 
 
-def test_sampled_out_response_releases_stashed_bodies(exporter: InMemorySpanExporter):
+def test_sampled_out_response_releases_stash(exporter: InMemorySpanExporter):
     set_config(write_token=WRITE_TOKEN, sample_on_response=lambda span: False)
     processor = ApitallySpanProcessor(SimpleSpanProcessor(exporter))
     provider = TracerProvider(sampler=ALWAYS_ON)
@@ -226,9 +226,9 @@ def test_sampled_out_response_releases_stashed_bodies(exporter: InMemorySpanExpo
     tracer = provider.get_tracer(CONTRIB_SCOPE)
 
     with tracer.start_as_current_span("POST /items", kind=SpanKind.SERVER) as span:
-        processor.stash_bodies(span.get_span_context().span_id, request_body=b'{"a": 1}')
+        processor.update_stash(span.get_span_context().span_id, request_body=b'{"a": 1}')
     assert exporter.get_finished_spans() == ()
-    assert processor.bodies == {}
+    assert processor.stash == {}
 
 
 def test_span_buffer_cap_bounds_kept_and_dropped_requests(exporter: InMemorySpanExporter):

--- a/tests/shared/test_wsgi.py
+++ b/tests/shared/test_wsgi.py
@@ -196,6 +196,22 @@ def test_request_body_not_read_for_disallowed_content_type(tracer: Tracer, expor
     assert environ["wsgi.input"] is spy
 
 
+def test_request_and_response_bodies_captured_together(tracer: Tracer, exporter: InMemorySpanExporter):
+    # The bodies are stashed in separate calls (response start vs finalize), covering the merge in stash_bodies
+    set_config(write_token=WRITE_TOKEN, log_request_body=True, log_response_body=True)
+
+    def app(environ: WSGIEnvironment, start_response: StartResponse) -> list[bytes]:
+        start_response("200 OK", [("Content-Type", "application/json")])
+        return [b'{"token": "abc"}']
+
+    body = b'{"password": "x", "user": "u"}'
+    environ = make_environ(method="POST", body=body, content_type="application/json", content_length=str(len(body)))
+    attributes = run_request(ApitallyWSGIMiddleware(app), environ, tracer, exporter)
+
+    assert json.loads(str(attributes["apitally.request.body"])) == {"password": REDACTED, "user": "u"}
+    assert json.loads(str(attributes["apitally.response.body"])) == {"token": REDACTED}
+
+
 def test_response_body_captured_from_chunks(tracer: Tracer, exporter: InMemorySpanExporter):
     set_config(write_token=WRITE_TOKEN, log_response_body=True)
     iterable = ClosingIterable([b'{"token": "abc", ', b'"id": 1}'])

--- a/tests/shared/test_wsgi.py
+++ b/tests/shared/test_wsgi.py
@@ -197,7 +197,7 @@ def test_request_body_not_read_for_disallowed_content_type(tracer: Tracer, expor
 
 
 def test_request_and_response_bodies_captured_together(tracer: Tracer, exporter: InMemorySpanExporter):
-    # The bodies are stashed in separate calls (response start vs finalize), covering the merge in stash_bodies
+    # The bodies are stashed in separate calls (response start vs finalize), covering the merge in update_stash
     set_config(write_token=WRITE_TOKEN, log_request_body=True, log_response_body=True)
 
     def app(environ: WSGIEnvironment, start_response: StartResponse) -> list[bytes]:
@@ -256,10 +256,10 @@ def test_request_headers_redacted(tracer: Tracer, exporter: InMemorySpanExporter
     attributes = run_request(ApitallyWSGIMiddleware(app), environ, tracer, exporter)
 
     assert attributes["http.request.header.authorization"] == [REDACTED]
-    assert attributes["http.request.header.accept"] == ("application/json",)
+    assert attributes["http.request.header.accept"] == ["application/json"]
     # CONTENT_TYPE and CONTENT_LENGTH live outside the HTTP_ environ namespace
-    assert attributes["http.request.header.content-type"] == ("text/plain",)
-    assert attributes["http.request.header.content-length"] == ("0",)
+    assert attributes["http.request.header.content-type"] == ["text/plain"]
+    assert attributes["http.request.header.content-length"] == ["0"]
 
 
 def test_sampled_out_request_produces_no_span(exporter: InMemorySpanExporter):

--- a/tests/test_blacksheep.py
+++ b/tests/test_blacksheep.py
@@ -105,8 +105,8 @@ async def test_unmatched_request_has_no_route_and_no_histogram_point(
 async def test_first_request_activates_and_records_without_lifespan(
     exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
 ):
-    # PRIVATE-API CANARY: init_apitally wraps app._handle_http, the one private-API
-    # dependency; fails loudly if BlackSheep renames or re-signatures it
+    # init_apitally wraps app._handle_http, the one private-API dependency; this assertion
+    # fails loudly if BlackSheep renames it or changes its signature
     assert list(inspect.signature(Application._handle_http).parameters) == ["self", "scope", "receive", "send"]
 
     allow_activation(monkeypatch)

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -98,7 +98,7 @@ def test_bodies_and_request_headers_captured_and_redacted(
     assert json.loads(str(span.attributes["apitally.request.body"])) == redacted
     assert json.loads(str(span.attributes["apitally.response.body"])) == redacted
     assert span.attributes["http.request.header.authorization"] == [REDACTED]
-    assert span.attributes["http.request.header.content-type"] == ("application/json",)
+    assert span.attributes["http.request.header.content-type"] == ["application/json"]
 
 
 def test_bodies_over_cap_replaced_with_sentinel(exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -212,7 +212,7 @@ def test_unhandled_exception_response_captured(
     assert response.status_code == 500
     (span,) = exported_spans(exporters)
     attributes = unwrap(span.attributes)
-    assert attributes["http.response.header.content-type"] == ("text/plain; charset=utf-8",)
+    assert attributes["http.response.header.content-type"] == ["text/plain; charset=utf-8"]
     assert attributes["apitally.response.body"] == "Internal Server Error"
     assert attributes["http.response.body.size"] == len("Internal Server Error")
 

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -204,7 +204,7 @@ def test_response_headers_include_headers_added_by_framework(
 
     (span,) = exported_spans(exporters)
     attributes = dict(span.attributes or {})
-    assert attributes["http.response.header.x-custom"] == ("value",)
+    assert attributes["http.response.header.x-custom"] == ["value"]
     # Content-Length is added by werkzeug after the view returns, so its presence proves
     # the headers were captured as sent, not as returned by the view
     assert "http.response.header.content-length" in attributes


### PR DESCRIPTION
## Summary

Capturing request and response bodies no longer delays responses. Previously, JSON parsing, per-key regex redaction, and user masking callbacks all ran on the request thread before the final response chunk was sent, and query param and header redaction ran on the request thread at span end. With both bodies logged at the 50 KB cap this added ~5 ms to a response and blocked the asyncio event loop for that time. All of it now runs on the OpenTelemetry batch export thread; the request thread only buffers raw bytes.

Measured cost of body processing per body (parse, redact, dump) that used to sit on the request thread:

| Body size | Cost |
|---|---|
| 1 KB | 43 µs |
| 8 KB | 400 µs |
| 48 KB | 2,460 µs |

In 0.x, masking ran on the writer thread; the v1 port had moved it onto the request thread. This restores the 0.x placement in the OTel architecture.

## How it works

- A new `ApitallySpanExporter` wraps the OTLP exporter and owns all redaction (query params, headers, body fields) and body processing, including the user masking callbacks.
- Middlewares hand raw body bytes to the span processor, which attaches them to a private copy of the ended span. The copy carries the bodies through the batch queue to the exporter, so if the queue drops a span, its bodies are freed with it and no separate cleanup is needed. A 2048-entry cap on the handoff dict guards against third-party instrumentors that never end a span.
- Raw bodies never become span attributes, and the private copy means spans received by user-attached span processors never hold them in any form.
- Body field and query param redaction decisions are cached per name, following the existing header cache. This cuts the redact step about 4x on the export thread.

## Behavior changes

- `apitally.request.body` and `apitally.response.body` no longer appear on spans received by the user's own exporters when Apitally attaches to an existing TracerProvider. Bodies are added only at Apitally's exporter.
- `mask_request_body` and `mask_response_body` run on the export thread after the response completes and receive the ended span (documented in MIGRATION.md, matching the 0.x contract). An invalid callback return degrades to `[REDACTED]`.
- A span that fails redaction at export is dropped instead of being exported unredacted; a failure processing one span never affects the rest of the batch.

## Tests

Existing transport tests now run through the exporter wrapper, so body capture, masking, and redaction stay pinned end to end. New tests cover the four properties that would regress silently: user-attached exporters never see bodies, sampled-out requests release stashed bodies, mask callbacks receive the ended span, and WSGI captures request and response bodies together on one request.

---

[![Compound Engineering](https://img.shields.io/badge/Built_with-Compound_Engineering-6366f1)](https://github.com/EveryInc/compound-engineering-plugin)
![Claude Code](https://img.shields.io/badge/Fable_5-D97757?logo=claude&logoColor=white)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves body parsing, header/query redaction, and masking off the request thread onto the OpenTelemetry export thread to cut latency and avoid blocking. Middlewares now stash raw body bytes and grouped headers; the new `ApitallySpanExporter` applies redaction, runs mask callbacks, and injects attributes during export, so user exporters never see Apitally‑captured headers or bodies.

- **Refactors**
  - Added `ApitallySpanExporter` in front of the delegate exporter to redact query params/headers on all spans, run `mask_request_body`/`mask_response_body` on the export thread, and add body/header attributes; spans that fail processing are dropped. Original spans are never mutated.
  - `ApitallySpanProcessor` stashes grouped request/response headers and raw bodies per SERVER span and attaches them to a private copy of the ended span during export; stash capped at 2,048 and cleared on shutdown or when sampled out.
  - `ASGI`, `WSGI`, and `Django` middlewares only set `[BODY_TOO_LARGE]` early and stash byte bodies and grouped headers; no redaction or header/body attributes on the request thread. Activation builds batch span processors with `ApitallySpanExporter` and reinstalls it after fork. Cached per-name decisions for body-field and query param redaction reduce export-time cost.

- **Migration**
  - `mask_request_body` and `mask_response_body` now run on a background export thread after the response completes and receive the ended SERVER span. Signature: `(span, body: bytes) -> bytes | None`. Returning `None` or a non-bytes value replaces the body with `[REDACTED]`. Do not rely on request-scoped state; keep callbacks fast.
  - When Apitally attaches to an existing `TracerProvider`, user exporters no longer see `apitally.request.body`, `apitally.response.body`, or Apitally-captured `http.*.header.*`; Apitally adds them only on its exporter path. `sample_on_response` cannot depend on captured headers/bodies as they are attached during export. Headers captured by OpenTelemetry instrumentation itself remain visible to your pipeline.

<sup>Written for commit 9b49acf5c7ad917701d7ef7354928e36a0251f98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/apitally/apitally-py/pull/320?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

