### PR TITLE
feat(v1): disk-backed write-through export spool

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -134,7 +134,7 @@ If your application already has an OpenTelemetry `TracerProvider` configured (e.
 
 ## Buffering and delivery
 
-Telemetry is buffered in gzip-compressed files in the system temp directory (set `TMPDIR` to relocate them) and exported to Apitally roughly every 15 seconds. If the Apitally endpoint is unreachable, buffered data survives downtime of up to an hour (capped at 50 MB on disk) and is delivered after recovery with original timestamps. On read-only filesystems the SDK falls back to a small in-memory buffer instead. All redaction and masking is applied before data is written to the buffer, so buffered files never contain unredacted data.
+Telemetry is buffered in gzip-compressed files in the system temp directory (set `TMPDIR` to relocate them) and exported to Apitally roughly every 15 seconds. If the Apitally endpoint is unreachable, buffered data survives downtime of up to an hour (capped at 50 MB on disk) and is delivered after recovery with original timestamps. On read-only filesystems the SDK falls back to a small in-memory buffer instead. All redaction and masking of captured request and response data is applied before anything is written to the buffer; captured application log messages are stored as your application emitted them (see the warning at the top).
 
 ## Version floors
 

--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -132,6 +132,10 @@ If your application already has an OpenTelemetry `TracerProvider` configured (e.
 - Your span attribute limits apply. A limit below 65,536 (e.g. via `OTEL_ATTRIBUTE_VALUE_LENGTH_LIMIT`) can truncate captured request/response bodies. The SDK logs a warning when it detects this.
 - Headers and bodies captured by Apitally never appear on the spans your own exporters receive. They are attached, already redacted, only on Apitally's export path. Headers captured by OpenTelemetry instrumentation itself (e.g. via `OTEL_INSTRUMENTATION_HTTP_CAPTURE_HEADERS_SERVER_REQUEST`) remain visible to your pipeline as usual.
 
+## Buffering and delivery
+
+Telemetry is buffered in gzip-compressed files in the system temp directory (set `TMPDIR` to relocate them) and exported to Apitally roughly every 15 seconds. If the Apitally endpoint is unreachable, buffered data survives downtime of up to an hour (capped at 50 MB on disk) and is delivered after recovery with original timestamps. On read-only filesystems the SDK falls back to a small in-memory buffer instead. All redaction and masking is applied before data is written to the buffer, so buffered files never contain unredacted data.
+
 ## Version floors
 
 - The minimum supported Litestar version is now 2.24 (was 2.4).

--- a/apitally/shared/activation.py
+++ b/apitally/shared/activation.py
@@ -13,11 +13,13 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from apitally.shared import config, metrics, providers, sentry
+from apitally.shared import config, export, metrics, providers, sentry
 from apitally.shared.config import TRUE_VALUES, ApitallyConfig
+from apitally.shared.export import ExportWorker
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.log_processor import ApitallyLogRecordProcessor, install_root_handler, uninstall_root_handler
 from apitally.shared.span_processor import ApitallySpanProcessor
+from apitally.shared.spool import Spool
 
 
 if TYPE_CHECKING:
@@ -37,6 +39,8 @@ resource: Resource | None = None
 span_processor: ApitallySpanProcessor | None = None
 log_processor: ApitallyLogRecordProcessor | None = None
 logger_provider: LoggerProvider | None = None
+spool: Spool | None = None
+export_worker: ExportWorker | None = None
 
 # OTel's own fork handlers hold weak references to batch processors; keep shut-down
 # instances alive so a later fork never calls a dead reference
@@ -141,18 +145,38 @@ def should_skip_activation() -> bool:
     )
 
 
-def create_batch_span_processor(env: str) -> BatchSpanProcessor:
-    return BatchSpanProcessor(ApitallySpanExporter(providers.create_span_exporter(env)))
+# Batch processor parameters are passed explicitly so the OTEL_BSP_* / OTEL_BLRP_* env
+# var fallbacks in the stock constructors never apply to this private pipeline
+def create_batch_span_processor(spool: Spool) -> BatchSpanProcessor:
+    return BatchSpanProcessor(
+        ApitallySpanExporter(export.create_span_exporter(spool)),
+        max_queue_size=export.BATCH_MAX_QUEUE_SIZE,
+        schedule_delay_millis=export.BATCH_SCHEDULE_DELAY_MILLIS,
+        max_export_batch_size=export.BATCH_MAX_EXPORT_BATCH_SIZE,
+        export_timeout_millis=export.BATCH_EXPORT_TIMEOUT_MILLIS,
+    )
+
+
+def create_batch_log_processor(spool: Spool) -> BatchLogRecordProcessor:
+    return BatchLogRecordProcessor(
+        export.create_log_exporter(spool),
+        max_queue_size=export.BATCH_MAX_QUEUE_SIZE,
+        schedule_delay_millis=export.BATCH_SCHEDULE_DELAY_MILLIS,
+        max_export_batch_size=export.BATCH_MAX_EXPORT_BATCH_SIZE,
+        export_timeout_millis=export.BATCH_EXPORT_TIMEOUT_MILLIS,
+    )
 
 
 def start_pipelines() -> None:
     global env, resource, span_processor, log_processor, logger_provider, inherited_span_processor
+    global spool, export_worker
     user_provider = providers.get_user_tracer_provider()
     env = providers.resolve_env(user_provider)
     # The resource is created here, not at configure, so every activating process mints
     # its own service.instance.id and carries the activation-resolved env
     resource = providers.create_resource(env)
     metrics.setup(resource)
+    spool = Spool()
     if inherited_span_processor is not None:
         # Forked child re-activation: swap in a fresh downstream batch processor, like
         # after_fork_in_parent, and drop the parent's in-flight and pending request state
@@ -163,19 +187,19 @@ def start_pipelines() -> None:
         span_processor.deferred.clear()
         span_processor.held.clear()
         span_processor.stash.clear()
-        span_processor.downstream = create_batch_span_processor(env)
+        span_processor.downstream = create_batch_span_processor(spool)
     else:
-        span_processor = ApitallySpanProcessor(create_batch_span_processor(env))
+        span_processor = ApitallySpanProcessor(create_batch_span_processor(spool))
         if user_provider is not None:
             providers.attach_to_tracer_provider(user_provider, span_processor)
         else:
             providers.setup_tracer_provider(resource, span_processor)
-    log_processor = ApitallyLogRecordProcessor(
-        BatchLogRecordProcessor(providers.create_log_exporter(env)), span_processor
-    )
+    log_processor = ApitallyLogRecordProcessor(create_batch_log_processor(spool), span_processor)
     logger_provider = providers.create_logger_provider(resource, [log_processor])
     install_root_handler(logger_provider, span_processor)
-    metrics.attach_reader(env)
+    metrics.attach_reader(spool)
+    export_worker = ExportWorker(spool, span_processor, log_processor, env)
+    export_worker.start()
 
 
 def before_fork() -> None:
@@ -186,6 +210,8 @@ def before_fork() -> None:
     if not activated:  # pragma: no cover
         return
     try:
+        if export_worker is not None:
+            export_worker.stop()
         metrics.detach_reader()
         if span_processor is not None:
             retired_processors.append(span_processor.downstream)
@@ -193,6 +219,11 @@ def before_fork() -> None:
         if log_processor is not None:
             retired_processors.append(log_processor.downstream)
             log_processor.downstream.shutdown()
+        if spool is not None:
+            # The processor shutdowns above drained their queues into the spool; closing
+            # the current files leaves no open gzip writer at the instant of fork, so the
+            # child cannot corrupt parent files through inherited file descriptors
+            spool.close_current_files()
     except Exception:  # pragma: no cover
         logger.exception("Error stopping Apitally threads before fork")
 
@@ -200,13 +231,18 @@ def before_fork() -> None:
 def after_fork_in_parent() -> None:
     """Re-activate by swapping fresh batch processors into the registered wrappers."""
     try:
-        if not activated or env is None:  # pragma: no cover
+        if not activated or spool is None:  # pragma: no cover
             return
         if span_processor is not None:
-            span_processor.downstream = create_batch_span_processor(env)
+            span_processor.downstream = create_batch_span_processor(spool)
         if log_processor is not None:
-            log_processor.downstream = BatchLogRecordProcessor(providers.create_log_exporter(env))
-        metrics.attach_reader(env)
+            log_processor.downstream = create_batch_log_processor(spool)
+        metrics.attach_reader(spool)
+        if export_worker is not None:
+            # Same spool, closed files intact; the next append opens a fresh current file.
+            # No re-wiring is needed because the worker resolves the repointed downstream
+            # processors and metric reader from module state each cycle
+            export_worker.start()
     except Exception:  # pragma: no cover
         logger.exception("Error re-activating Apitally after fork")
     finally:
@@ -214,9 +250,13 @@ def after_fork_in_parent() -> None:
 
 
 def after_fork_in_child() -> None:
-    """Reset to configured state. Child activates itself if it ever serves."""
+    """Reset to configured state. Child activates itself if it ever serves. The inherited
+    spool and worker are abandoned without flushing, closing or unlinking anything; the
+    spool deletes files only through explicit calls, so dropping the references can never
+    touch the parent's files."""
     global activation_lock, activation_attempted, activated, env, resource
     global span_processor, log_processor, logger_provider, inherited_span_processor
+    global spool, export_worker
     activation_lock = threading.Lock()
     if not activated:  # pragma: no cover
         return
@@ -233,19 +273,26 @@ def after_fork_in_child() -> None:
     span_processor = None
     log_processor = None
     logger_provider = None
+    spool = None
+    export_worker = None
 
 
 def reset() -> None:
     """Full teardown for tests. Shuts down and drops all pipeline state."""
     global activation_lock, activation_attempted, activated, env, resource
     global span_processor, log_processor, logger_provider, inherited_span_processor
+    global spool, export_worker
     activation_lock = threading.Lock()
     uninstall_root_handler()
     metrics.reset()
+    if export_worker is not None:
+        export_worker.stop(timeout=1.0)
     if span_processor is not None:
         span_processor.downstream.shutdown()
     if log_processor is not None:
         log_processor.downstream.shutdown()
+    if spool is not None:
+        spool.clear()
     activation_attempted = False
     activated = False
     env = None
@@ -254,4 +301,6 @@ def reset() -> None:
     log_processor = None
     logger_provider = None
     inherited_span_processor = None
+    spool = None
+    export_worker = None
     on_activate_hooks.clear()

--- a/apitally/shared/activation.py
+++ b/apitally/shared/activation.py
@@ -134,18 +134,16 @@ class WSGIActivationShim:
 
 
 def should_skip_activation() -> bool:
-    # The PYTEST_CURRENT_TEST check detects pytest; the argv check detects Django's "manage.py test"
     cfg = config.get_config()
     return (
         cfg is None
         or cfg.disabled
         or bool(os.environ.get("PYTEST_CURRENT_TEST"))
-        or sys.argv[1:2] == ["test"]
+        or sys.argv[1:2] == ["test"]  # detects Django's "manage.py test"
         or (os.environ.get("APITALLY_DISABLED") or "").strip().lower() in TRUE_VALUES
     )
 
 
-# All four parameters passed explicitly; see the rationale on the BATCH_* constants
 def create_batch_span_processor(spool: Spool) -> BatchSpanProcessor:
     return BatchSpanProcessor(
         ApitallySpanExporter(export.create_span_exporter(spool)),
@@ -171,8 +169,6 @@ def start_pipelines() -> None:
     global spool, export_worker
     user_provider = providers.get_user_tracer_provider()
     env = providers.resolve_env(user_provider)
-    # The resource is created here, not at configure, so every activating process mints
-    # its own service.instance.id and carries the activation-resolved env
     resource = providers.create_resource(env)
     metrics.setup(resource)
     spool = Spool()
@@ -203,8 +199,6 @@ def start_pipelines() -> None:
 
 def before_fork() -> None:
     """Stop all SDK-owned threads so none are running at the instant of fork."""
-    # Held across the fork so an in-flight activate completes first; released in both after
-    # handlers (the child gets a fresh lock, since an inherited locked mutex would deadlock)
     activation_lock.acquire()
     if not activated:  # pragma: no cover
         return
@@ -219,9 +213,6 @@ def before_fork() -> None:
             retired_processors.append(log_processor.downstream)
             log_processor.downstream.shutdown()
         if spool is not None:
-            # The processor shutdowns above drained their queues into the spool; closing
-            # the current files leaves no open gzip writer at the instant of fork, so the
-            # child cannot corrupt parent files through inherited file descriptors
             spool.close_current_files()
     except Exception:  # pragma: no cover
         logger.exception("Error stopping Apitally threads before fork")
@@ -238,9 +229,6 @@ def after_fork_in_parent() -> None:
             log_processor.downstream = create_batch_log_processor(spool)
         metrics.attach_reader(spool)
         if export_worker is not None:
-            # Same spool, closed files intact; the next append opens a fresh current file.
-            # No re-wiring is needed because the worker resolves the repointed downstream
-            # processors and metric reader from module state each cycle
             export_worker.start()
     except Exception:  # pragma: no cover
         logger.exception("Error re-activating Apitally after fork")
@@ -249,10 +237,8 @@ def after_fork_in_parent() -> None:
 
 
 def after_fork_in_child() -> None:
-    """Reset to configured state. Child activates itself if it ever serves. The inherited
-    spool and worker are abandoned without flushing, closing or unlinking anything; the
-    spool deletes files only through explicit calls, so dropping the references can never
-    touch the parent's files."""
+    """Reset to configured state; the child activates itself if it ever serves. Abandoning
+    the inherited spool is safe: it deletes files only through explicit calls."""
     global activation_lock, activation_attempted, activated, env, resource
     global span_processor, log_processor, logger_provider, inherited_span_processor
     global spool, export_worker

--- a/apitally/shared/activation.py
+++ b/apitally/shared/activation.py
@@ -145,8 +145,7 @@ def should_skip_activation() -> bool:
     )
 
 
-# Batch processor parameters are passed explicitly so the OTEL_BSP_* / OTEL_BLRP_* env
-# var fallbacks in the stock constructors never apply to this private pipeline
+# All four parameters passed explicitly; see the rationale on the BATCH_* constants
 def create_batch_span_processor(spool: Spool) -> BatchSpanProcessor:
     return BatchSpanProcessor(
         ApitallySpanExporter(export.create_span_exporter(spool)),

--- a/apitally/shared/capture.py
+++ b/apitally/shared/capture.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 from apitally.shared.config import ApitallyConfig, get_config
 
 

--- a/apitally/shared/export.py
+++ b/apitally/shared/export.py
@@ -1,9 +1,15 @@
 from __future__ import annotations
 
+import atexit
 import logging
+import random
+import threading
 from collections.abc import MutableMapping, Sequence
-from typing import cast
+from typing import TYPE_CHECKING, cast
 
+import requests
+from opentelemetry import context as otel_context
+from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
 from opentelemetry.sdk._logs import ReadableLogRecord
@@ -12,7 +18,14 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.util.types import AnyValue
 
-from apitally.shared.spool import Spool, duplicate_log_filter
+from apitally.shared import metrics
+from apitally.shared.providers import DISTRO_VERSION, endpoint_url, export_headers
+from apitally.shared.spool import Spool, SpoolFile, duplicate_log_filter
+
+
+if TYPE_CHECKING:
+    from apitally.shared.log_processor import ApitallyLogRecordProcessor
+    from apitally.shared.span_processor import ApitallySpanProcessor
 
 
 logger = logging.getLogger(__name__)
@@ -32,6 +45,15 @@ BATCH_SCHEDULE_DELAY_MILLIS = 1_000
 BATCH_MAX_QUEUE_SIZE = 2_048
 BATCH_MAX_EXPORT_BATCH_SIZE = 512
 BATCH_EXPORT_TIMEOUT_MILLIS = 30_000
+
+DEFAULT_EXPORT_INTERVAL = 15.0
+INITIAL_EXPORT_DELAY = 2.0
+EXPORT_INTERVAL_HEADER = "Apitally-Export-Interval"
+MIN_EXPORT_INTERVAL = 5
+MAX_EXPORT_INTERVAL = 900
+REQUEST_TIMEOUT = 10
+MAX_SENDS_PER_CYCLE = 10
+RETRYABLE_STATUS_CODES = frozenset({408, 429})
 
 
 class SpoolSpanExporter(SpanExporter):
@@ -73,6 +95,158 @@ class SpoolLogExporter(LogRecordExporter):
 
     def force_flush(self, timeout_millis: int = 30000) -> bool:
         return True
+
+
+class ExportWorker:
+    """Background thread that runs every export interval: flushes the batch processors
+    into the spool, collects metrics, rotates spool files and sends them to the OTLP
+    endpoint oldest-first. A failed file simply waits for the next cycle; the spool is
+    the retry buffer, so there is no backoff.
+
+    The worker stores no references to the batch processors or the metric reader; each
+    cycle resolves them through the stable identities (the processor wrappers' downstream
+    attributes and the metrics module state), which the fork handlers repoint to fresh
+    instances after a fork."""
+
+    def __init__(
+        self,
+        spool: Spool,
+        span_processor: ApitallySpanProcessor,
+        log_processor: ApitallyLogRecordProcessor,
+        env: str,
+    ) -> None:
+        self.spool = spool
+        self.span_processor = span_processor
+        self.log_processor = log_processor
+        self.interval: float = DEFAULT_EXPORT_INTERVAL
+        self.session = requests.Session()
+        self.headers = {
+            **export_headers(env),
+            "Content-Type": "application/x-protobuf",
+            "Content-Encoding": "gzip",
+            "User-Agent": f"apitally-py/{DISTRO_VERSION}",
+        }
+        self.warned_statuses: set[int] = set()
+        self.stop_event = threading.Event()
+        self.thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        if self.thread is not None and self.thread.is_alive():  # pragma: no cover
+            return
+        # A fresh Event per thread: if a previous thread outlived its join timeout, it
+        # keeps observing its own set event and exits instead of racing the new thread
+        self.stop_event = threading.Event()
+        self.thread = threading.Thread(
+            target=self.run, args=(self.stop_event,), name="ApitallyExportWorker", daemon=True
+        )
+        self.thread.start()
+        atexit.register(self.shutdown)
+
+    def stop(self, timeout: float = 5.0) -> None:
+        atexit.unregister(self.shutdown)
+        self.stop_event.set()
+        if self.thread is not None and self.thread.is_alive():
+            self.thread.join(timeout)
+
+    def shutdown(self) -> None:
+        """Stop the thread, then a final drain: flush everything recorded so far, rotate,
+        and attempt one unpaced send pass."""
+        self.stop()
+        try:
+            self.run_cycle(None)
+        except Exception:  # pragma: no cover
+            logger.debug("Error in final Apitally export on shutdown", exc_info=True)
+
+    def run(self, stop_event: threading.Event) -> None:
+        delay = INITIAL_EXPORT_DELAY
+        while not stop_event.wait(delay):
+            try:
+                self.run_cycle(stop_event)
+            except Exception:
+                logger.warning("Error in Apitally export cycle", exc_info=True)
+            # Jitter desynchronizes fleets whose processes started together in a deploy
+            delay = self.interval * random.uniform(0.9, 1.1)
+
+    def run_cycle(self, stop_event: threading.Event | None) -> None:
+        # The suppression key keeps our own flushes and POSTs from generating telemetry
+        # that would feed back into the pipeline
+        token = otel_context.attach(otel_context.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
+        try:
+            self.span_processor.downstream.force_flush()
+            self.log_processor.downstream.force_flush()
+            if metrics.reader is not None:
+                metrics.reader.collect()
+            self.spool.rotate_for_export()
+            self.spool.touch_files()
+            self.send_pending(stop_event)
+        finally:
+            otel_context.detach(token)
+
+    def send_pending(self, stop_event: threading.Event | None) -> None:
+        """Send closed files oldest-first, capped per cycle, with short jittered sleeps
+        between sends. During an outage this amounts to one probe POST per cycle. The
+        final drain on shutdown passes no stop event and runs unpaced."""
+        sent = 0
+        for file in self.spool.pending_files():
+            if sent >= MAX_SENDS_PER_CYCLE or (stop_event is not None and stop_event.is_set()):
+                return
+            if file.expired():
+                # Checked immediately before each POST: a retry landing outside the
+                # server's dedup window could double-ingest
+                logger.warning("Buffered %s could not be delivered within an hour and was dropped", file.signal)
+                self.spool.delete_file(file)
+                continue
+            if sent > 0 and stop_event is not None and stop_event.wait(random.uniform(0.1, 0.5)):
+                return
+            sent += 1
+            if not self.send_file(file):
+                return
+
+    def send_file(self, file: SpoolFile) -> bool:
+        """Send one file's bytes verbatim. Returns False when the cycle should end
+        because of a retryable failure; the file stays queued for the next cycle."""
+        try:
+            body = file.read_bytes()
+        except (OSError, ValueError):
+            # An unreadable file must not block the queue
+            logger.warning("Error reading buffered %s, dropping it", file.signal, exc_info=True)
+            self.spool.delete_file(file)
+            return True
+        file.mark_attempt()
+        url = endpoint_url(f"/v1/{file.signal}")
+        try:
+            try:
+                response = self.session.post(url, data=body, headers=self.headers, timeout=REQUEST_TIMEOUT)
+            except requests.ConnectionError:
+                # The server may close an idle keep-alive connection mid-request; one
+                # immediate retry, like the stock OTLP exporter
+                response = self.session.post(url, data=body, headers=self.headers, timeout=REQUEST_TIMEOUT)
+        except (requests.ConnectionError, requests.Timeout):
+            logger.debug("Sending buffered %s to Apitally failed with a connection error, will retry", file.signal)
+            return False
+        self.apply_interval_header(response)
+        if 200 <= response.status_code < 300:
+            self.spool.delete_file(file)
+            return True
+        if response.status_code in RETRYABLE_STATUS_CODES or response.status_code >= 500:
+            logger.debug(
+                "Sending buffered %s to Apitally failed with HTTP %d, will retry", file.signal, response.status_code
+            )
+            return False
+        if response.status_code not in self.warned_statuses:
+            self.warned_statuses.add(response.status_code)
+            logger.warning("Apitally rejected buffered %s with HTTP %d, dropping it", file.signal, response.status_code)
+        self.spool.delete_file(file)
+        return True
+
+    def apply_interval_header(self, response: requests.Response) -> None:
+        value = response.headers.get(EXPORT_INTERVAL_HEADER)
+        if value:
+            try:
+                seconds = int(value)
+            except ValueError:
+                return
+            self.interval = float(min(max(seconds, MIN_EXPORT_INTERVAL), MAX_EXPORT_INTERVAL))
 
 
 def chunked(batch: Sequence) -> list[Sequence]:

--- a/apitally/shared/export.py
+++ b/apitally/shared/export.py
@@ -1,0 +1,100 @@
+from __future__ import annotations
+
+import logging
+from collections.abc import MutableMapping, Sequence
+from typing import cast
+
+from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
+from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
+from opentelemetry.sdk._logs import ReadableLogRecord
+from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
+from opentelemetry.sdk.trace import ReadableSpan
+from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.util.types import AnyValue
+
+from apitally.shared.spool import Spool, duplicate_log_filter
+
+
+logger = logging.getLogger(__name__)
+logger.addFilter(duplicate_log_filter)
+
+# Sub-batch size for encoding: with every per-record input capped, a chunk stays far below
+# the spool's rotation threshold, so no single append can overshoot the file size bound
+ENCODE_CHUNK_SIZE = 32
+
+# The server caps log messages at this length; matches 0.x MAX_LOG_MSG_LENGTH
+MAX_LOG_VALUE_LENGTH = 2048
+
+# Batch processor parameters are always passed explicitly, because the stock constructors
+# fall back to OTEL_BSP_* / OTEL_BLRP_* env vars for any parameter left as None and this
+# private pipeline must not be tuned by env vars aimed at the user's own exporters
+BATCH_SCHEDULE_DELAY_MILLIS = 1_000
+BATCH_MAX_QUEUE_SIZE = 2_048
+BATCH_MAX_EXPORT_BATCH_SIZE = 512
+BATCH_EXPORT_TIMEOUT_MILLIS = 30_000
+
+
+class SpoolSpanExporter(SpanExporter):
+    """Terminal exporter behind the batch span processor: encodes drained batches to
+    protobuf and appends them to the spool."""
+
+    def __init__(self, spool: Spool) -> None:
+        self.spool = spool
+
+    def export(self, spans: Sequence[ReadableSpan]) -> SpanExportResult:
+        for chunk in chunked(spans):
+            self.spool.append("traces", encode_spans(chunk).SerializeToString())
+        return SpanExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        # The spool's lifecycle is owned by activation
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+
+class SpoolLogExporter(LogRecordExporter):
+    """Terminal exporter behind the batch log record processor: truncates oversized
+    records, encodes to protobuf and appends to the spool."""
+
+    def __init__(self, spool: Spool) -> None:
+        self.spool = spool
+
+    def export(self, batch: Sequence[ReadableLogRecord]) -> LogRecordExportResult:
+        for record in batch:
+            truncate_log_record(record)
+        for chunk in chunked(batch):
+            self.spool.append("logs", encode_logs(chunk).SerializeToString())
+        return LogRecordExportResult.SUCCESS
+
+    def shutdown(self) -> None:
+        pass
+
+    def force_flush(self, timeout_millis: int = 30000) -> bool:
+        return True
+
+
+def chunked(batch: Sequence) -> list[Sequence]:
+    return [batch[i : i + ENCODE_CHUNK_SIZE] for i in range(0, len(batch), ENCODE_CHUNK_SIZE)]
+
+
+def truncate_log_record(record: ReadableLogRecord) -> None:
+    """Cut oversized body strings and attribute values. Nothing upstream bounds a log
+    record body, and a single unbounded record would break the spool's file size bound.
+    Records from the SDK's own "apitally" scope (e.g. the startup event, whose JSON body
+    may legitimately be long) are exempt; their sizes are SDK-controlled."""
+    if record.instrumentation_scope is not None and record.instrumentation_scope.name == "apitally":
+        return
+    log_record = record.log_record
+    if isinstance(log_record.body, str) and len(log_record.body) > MAX_LOG_VALUE_LENGTH:
+        log_record.body = log_record.body[:MAX_LOG_VALUE_LENGTH]
+    if log_record.attributes:
+        oversized = [
+            (key, value)
+            for key, value in log_record.attributes.items()
+            if isinstance(value, str) and len(value) > MAX_LOG_VALUE_LENGTH
+        ]
+        attributes = cast("MutableMapping[str, AnyValue]", log_record.attributes)
+        for key, value in oversized:
+            attributes[key] = value[:MAX_LOG_VALUE_LENGTH]

--- a/apitally/shared/export.py
+++ b/apitally/shared/export.py
@@ -40,7 +40,9 @@ MAX_LOG_VALUE_LENGTH = 2048
 
 # Batch processor parameters are always passed explicitly, because the stock constructors
 # fall back to OTEL_BSP_* / OTEL_BLRP_* env vars for any parameter left as None and this
-# private pipeline must not be tuned by env vars aimed at the user's own exporters
+# private pipeline must not be tuned by env vars aimed at the user's own exporters. The
+# schedule delay is lowered so telemetry reaches the spool fast; the other values are the
+# stock defaults
 BATCH_SCHEDULE_DELAY_MILLIS = 1_000
 BATCH_MAX_QUEUE_SIZE = 2_048
 BATCH_MAX_EXPORT_BATCH_SIZE = 512

--- a/apitally/shared/export.py
+++ b/apitally/shared/export.py
@@ -35,7 +35,7 @@ logger.addFilter(duplicate_log_filter)
 # the spool's rotation threshold, so no single append can overshoot the file size bound
 ENCODE_CHUNK_SIZE = 32
 
-# The server caps log messages at this length; matches 0.x MAX_LOG_MSG_LENGTH
+# The server caps log messages at this length
 MAX_LOG_VALUE_LENGTH = 2048
 
 # Batch processor parameters are always passed explicitly, because the stock constructors
@@ -129,9 +129,14 @@ class ExportWorker:
         self.warned_statuses: set[int] = set()
         self.stop_event = threading.Event()
         self.thread: threading.Thread | None = None
+        # Per-instance generator: forked children inherit the module-level random state,
+        # which would make every process in a fleet draw identical jitter
+        self.random = random.Random()
 
     def start(self) -> None:
-        if self.thread is not None and self.thread.is_alive():  # pragma: no cover
+        # A thread whose stop event is set is already winding down (its join timed out,
+        # e.g. mid-POST at fork time) and must not block the restart
+        if self.thread is not None and self.thread.is_alive() and not self.stop_event.is_set():  # pragma: no cover
             return
         # A fresh Event per thread: if a previous thread outlived its join timeout, it
         # keeps observing its own set event and exits instead of racing the new thread
@@ -165,7 +170,7 @@ class ExportWorker:
             except Exception:
                 logger.warning("Error in Apitally export cycle", exc_info=True)
             # Jitter desynchronizes fleets whose processes started together in a deploy
-            delay = self.interval * random.uniform(0.9, 1.1)
+            delay = self.interval * self.random.uniform(0.9, 1.1)
 
     def run_cycle(self, stop_event: threading.Event | None) -> None:
         # The suppression key keeps our own flushes and POSTs from generating telemetry
@@ -190,14 +195,14 @@ class ExportWorker:
         for file in self.spool.pending_files():
             if sent >= MAX_SENDS_PER_CYCLE or (stop_event is not None and stop_event.is_set()):
                 return
+            if sent > 0 and stop_event is not None and stop_event.wait(self.random.uniform(0.1, 0.5)):
+                return
             if file.expired():
                 # Checked immediately before each POST: a retry landing outside the
                 # server's dedup window could double-ingest
                 logger.warning("Buffered %s could not be delivered within an hour and was dropped", file.signal)
                 self.spool.delete_file(file)
                 continue
-            if sent > 0 and stop_event is not None and stop_event.wait(random.uniform(0.1, 0.5)):
-                return
             sent += 1
             if not self.send_file(file):
                 return

--- a/apitally/shared/export.py
+++ b/apitally/shared/export.py
@@ -249,6 +249,16 @@ class ExportWorker:
             self.interval = float(min(max(seconds, MIN_EXPORT_INTERVAL), MAX_EXPORT_INTERVAL))
 
 
+# Factory seam: activation resolves these through the module so tests can substitute
+# in-memory exporters
+def create_span_exporter(spool: Spool) -> SpanExporter:
+    return SpoolSpanExporter(spool)
+
+
+def create_log_exporter(spool: Spool) -> LogRecordExporter:
+    return SpoolLogExporter(spool)
+
+
 def chunked(batch: Sequence) -> list[Sequence]:
     return [batch[i : i + ENCODE_CHUNK_SIZE] for i in range(0, len(batch), ENCODE_CHUNK_SIZE)]
 

--- a/apitally/shared/export.py
+++ b/apitally/shared/export.py
@@ -60,9 +60,6 @@ class SpoolSpanExporter(SpanExporter):
         # The spool's lifecycle is owned by activation
         pass
 
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
-        return True
-
 
 class SpoolLogExporter(LogRecordExporter):
     """Truncates oversized log records, encodes to protobuf and appends them to the spool."""
@@ -79,9 +76,6 @@ class SpoolLogExporter(LogRecordExporter):
 
     def shutdown(self) -> None:
         pass
-
-    def force_flush(self, timeout_millis: int = 30000) -> bool:
-        return True
 
 
 class ExportWorker:
@@ -141,7 +135,7 @@ class ExportWorker:
         while not stop_event.wait(delay):
             try:
                 self.run_cycle(stop_event)
-            except Exception:
+            except Exception:  # pragma: no cover
                 logger.debug("Error in Apitally export cycle", exc_info=True)
             # Jitter desynchronizes deployments whose processes started together
             delay = self.interval * self.random.uniform(0.9, 1.1)

--- a/apitally/shared/export.py
+++ b/apitally/shared/export.py
@@ -1,11 +1,9 @@
-from __future__ import annotations
-
 import atexit
 import logging
 import random
 import threading
 from collections.abc import MutableMapping, Sequence
-from typing import TYPE_CHECKING, cast
+from typing import cast
 
 import requests
 from opentelemetry import context as otel_context
@@ -19,30 +17,19 @@ from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
 from opentelemetry.util.types import AnyValue
 
 from apitally.shared import metrics
+from apitally.shared.log_processor import ApitallyLogRecordProcessor
 from apitally.shared.providers import DISTRO_VERSION, endpoint_url, export_headers
-from apitally.shared.spool import Spool, SpoolFile, duplicate_log_filter
-
-
-if TYPE_CHECKING:
-    from apitally.shared.log_processor import ApitallyLogRecordProcessor
-    from apitally.shared.span_processor import ApitallySpanProcessor
+from apitally.shared.span_processor import ApitallySpanProcessor
+from apitally.shared.spool import Spool, SpoolFile
 
 
 logger = logging.getLogger(__name__)
-logger.addFilter(duplicate_log_filter)
 
-# Sub-batch size for encoding: with every per-record input capped, a chunk stays far below
-# the spool's rotation threshold, so no single append can overshoot the file size bound
+# Small enough that no single append can overshoot the spool's rotation threshold
 ENCODE_CHUNK_SIZE = 32
 
-# The server caps log messages at this length
 MAX_LOG_VALUE_LENGTH = 2048
 
-# Batch processor parameters are always passed explicitly, because the stock constructors
-# fall back to OTEL_BSP_* / OTEL_BLRP_* env vars for any parameter left as None and this
-# private pipeline must not be tuned by env vars aimed at the user's own exporters. The
-# schedule delay is lowered so telemetry reaches the spool fast; the other values are the
-# stock defaults
 BATCH_SCHEDULE_DELAY_MILLIS = 1_000
 BATCH_MAX_QUEUE_SIZE = 2_048
 BATCH_MAX_EXPORT_BATCH_SIZE = 512
@@ -52,15 +39,14 @@ DEFAULT_EXPORT_INTERVAL = 15.0
 INITIAL_EXPORT_DELAY = 2.0
 EXPORT_INTERVAL_HEADER = "Apitally-Export-Interval"
 MIN_EXPORT_INTERVAL = 5
-MAX_EXPORT_INTERVAL = 900
+MAX_EXPORT_INTERVAL = 60
 REQUEST_TIMEOUT = 10
 MAX_SENDS_PER_CYCLE = 10
 RETRYABLE_STATUS_CODES = frozenset({408, 429})
 
 
 class SpoolSpanExporter(SpanExporter):
-    """Terminal exporter behind the batch span processor: encodes drained batches to
-    protobuf and appends them to the spool."""
+    """Encodes drained span batches to protobuf and appends them to the spool."""
 
     def __init__(self, spool: Spool) -> None:
         self.spool = spool
@@ -79,8 +65,7 @@ class SpoolSpanExporter(SpanExporter):
 
 
 class SpoolLogExporter(LogRecordExporter):
-    """Terminal exporter behind the batch log record processor: truncates oversized
-    records, encodes to protobuf and appends to the spool."""
+    """Truncates oversized log records, encodes to protobuf and appends them to the spool."""
 
     def __init__(self, spool: Spool) -> None:
         self.spool = spool
@@ -100,15 +85,7 @@ class SpoolLogExporter(LogRecordExporter):
 
 
 class ExportWorker:
-    """Background thread that runs every export interval: flushes the batch processors
-    into the spool, collects metrics, rotates spool files and sends them to the OTLP
-    endpoint oldest-first. A failed file simply waits for the next cycle; the spool is
-    the retry buffer, so there is no backoff.
-
-    The worker stores no references to the batch processors or the metric reader; each
-    cycle resolves them through the stable identities (the processor wrappers' downstream
-    attributes and the metrics module state), which the fork handlers repoint to fresh
-    instances after a fork."""
+    """Background thread sending spool files to the OTLP endpoint every export interval."""
 
     def __init__(
         self,
@@ -131,17 +108,13 @@ class ExportWorker:
         self.warned_statuses: set[int] = set()
         self.stop_event = threading.Event()
         self.thread: threading.Thread | None = None
-        # Per-instance generator: forked children inherit the module-level random state,
-        # which would make every process in a fleet draw identical jitter
         self.random = random.Random()
 
     def start(self) -> None:
-        # A thread whose stop event is set is already winding down (its join timed out,
-        # e.g. mid-POST at fork time) and must not block the restart
+        # A thread whose stop event is set is winding down (join timed out) and must not block the restart
         if self.thread is not None and self.thread.is_alive() and not self.stop_event.is_set():  # pragma: no cover
             return
-        # A fresh Event per thread: if a previous thread outlived its join timeout, it
-        # keeps observing its own set event and exits instead of racing the new thread
+        # Fresh Event per thread: a thread that outlived its join timeout exits on its own set event
         self.stop_event = threading.Event()
         self.thread = threading.Thread(
             target=self.run, args=(self.stop_event,), name="ApitallyExportWorker", daemon=True
@@ -156,8 +129,7 @@ class ExportWorker:
             self.thread.join(timeout)
 
     def shutdown(self) -> None:
-        """Stop the thread, then a final drain: flush everything recorded so far, rotate,
-        and attempt one unpaced send pass."""
+        """Stop the thread and attempt one final unpaced drain-and-send pass."""
         self.stop()
         try:
             self.run_cycle(None)
@@ -170,13 +142,12 @@ class ExportWorker:
             try:
                 self.run_cycle(stop_event)
             except Exception:
-                logger.warning("Error in Apitally export cycle", exc_info=True)
-            # Jitter desynchronizes fleets whose processes started together in a deploy
+                logger.debug("Error in Apitally export cycle", exc_info=True)
+            # Jitter desynchronizes deployments whose processes started together
             delay = self.interval * self.random.uniform(0.9, 1.1)
 
     def run_cycle(self, stop_event: threading.Event | None) -> None:
-        # The suppression key keeps our own flushes and POSTs from generating telemetry
-        # that would feed back into the pipeline
+        # Suppress instrumentation so our own flushes and POSTs generate no telemetry
         token = otel_context.attach(otel_context.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         try:
             self.span_processor.downstream.force_flush()
@@ -190,18 +161,16 @@ class ExportWorker:
             otel_context.detach(token)
 
     def send_pending(self, stop_event: threading.Event | None) -> None:
-        """Send closed files oldest-first, capped per cycle, with short jittered sleeps
-        between sends. During an outage this amounts to one probe POST per cycle. The
-        final drain on shutdown passes no stop event and runs unpaced."""
+        """During an outage this amounts to one probe POST per cycle. The final drain on
+        shutdown passes no stop event and runs unpaced."""
         sent = 0
         for file in self.spool.pending_files():
             if sent >= MAX_SENDS_PER_CYCLE or (stop_event is not None and stop_event.is_set()):
                 return
             if sent > 0 and stop_event is not None and stop_event.wait(self.random.uniform(0.1, 0.5)):
                 return
-            if file.expired():
-                # Checked immediately before each POST: a retry landing outside the
-                # server's dedup window could double-ingest
+            if file.is_expired():
+                # A retry landing outside the server's dedup window could double-ingest
                 logger.warning("Buffered %s could not be delivered within an hour and was dropped", file.signal)
                 self.spool.delete_file(file)
                 continue
@@ -210,27 +179,25 @@ class ExportWorker:
                 return
 
     def send_file(self, file: SpoolFile) -> bool:
-        """Send one file's bytes verbatim. Returns False when the cycle should end
-        because of a retryable failure; the file stays queued for the next cycle."""
-        try:
-            body = file.read_bytes()
-        except (OSError, ValueError):
-            # An unreadable file must not block the queue
-            logger.warning("Error reading buffered %s, dropping it", file.signal, exc_info=True)
-            self.spool.delete_file(file)
-            return True
+        """Streams the file's bytes verbatim. Returns False on a retryable failure, which
+        ends the cycle and keeps the file queued."""
         file.mark_attempt()
         url = endpoint_url(f"/v1/{file.signal}")
         try:
             try:
-                response = self.session.post(url, data=body, headers=self.headers, timeout=REQUEST_TIMEOUT)
+                file.sink.seek(0)
+                response = self.session.post(url, data=file.sink, headers=self.headers, timeout=REQUEST_TIMEOUT)
             except requests.ConnectionError:
-                # The server may close an idle keep-alive connection mid-request; one
-                # immediate retry, like the stock OTLP exporter
-                response = self.session.post(url, data=body, headers=self.headers, timeout=REQUEST_TIMEOUT)
+                # The server may close an idle keep-alive connection mid-request; retry once
+                file.sink.seek(0)
+                response = self.session.post(url, data=file.sink, headers=self.headers, timeout=REQUEST_TIMEOUT)
         except (requests.ConnectionError, requests.Timeout):
             logger.debug("Sending buffered %s to Apitally failed with a connection error, will retry", file.signal)
             return False
+        except (OSError, ValueError):
+            logger.warning("Error reading buffered %s, dropping it", file.signal, exc_info=True)
+            self.spool.delete_file(file)
+            return True
         self.apply_interval_header(response)
         if 200 <= response.status_code < 300:
             self.spool.delete_file(file)
@@ -256,8 +223,6 @@ class ExportWorker:
             self.interval = float(min(max(seconds, MIN_EXPORT_INTERVAL), MAX_EXPORT_INTERVAL))
 
 
-# Factory seam: activation resolves these through the module so tests can substitute
-# in-memory exporters
 def create_span_exporter(spool: Spool) -> SpanExporter:
     return SpoolSpanExporter(spool)
 
@@ -271,10 +236,6 @@ def chunked(batch: Sequence) -> list[Sequence]:
 
 
 def truncate_log_record(record: ReadableLogRecord) -> None:
-    """Cut oversized body strings and attribute values. Nothing upstream bounds a log
-    record body, and a single unbounded record would break the spool's file size bound.
-    Records from the SDK's own "apitally" scope (e.g. the startup event, whose JSON body
-    may legitimately be long) are exempt; their sizes are SDK-controlled."""
     if record.instrumentation_scope is not None and record.instrumentation_scope.name == "apitally":
         return
     log_record = record.log_record
@@ -286,6 +247,6 @@ def truncate_log_record(record: ReadableLogRecord) -> None:
             for key, value in log_record.attributes.items()
             if isinstance(value, str) and len(value) > MAX_LOG_VALUE_LENGTH
         ]
-        attributes = cast("MutableMapping[str, AnyValue]", log_record.attributes)
+        attributes = cast(MutableMapping[str, AnyValue], log_record.attributes)
         for key, value in oversized:
             attributes[key] = value[:MAX_LOG_VALUE_LENGTH]

--- a/apitally/shared/metrics.py
+++ b/apitally/shared/metrics.py
@@ -1,20 +1,19 @@
-import atexit
 import time
 from collections.abc import Iterable
 from typing import Any
 
+from opentelemetry.exporter.otlp.proto.common.metrics_encoder import encode_metrics
 from opentelemetry.instrumentation.system_metrics import SystemMetricsInstrumentor
 from opentelemetry.metrics import CallbackOptions, Histogram, Observation
 from opentelemetry.sdk.metrics import Histogram as SDKHistogram
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import AggregationTemporality, MetricExporter, PeriodicExportingMetricReader
+from opentelemetry.sdk.metrics.export import AggregationTemporality, MetricReader, MetricsData
 from opentelemetry.sdk.metrics.view import Aggregation, ExponentialBucketHistogramAggregation
 from opentelemetry.sdk.resources import Resource
 
-from apitally.shared.providers import create_meter_provider, create_metric_exporter
+from apitally.shared.providers import create_meter_provider
+from apitally.shared.spool import Spool
 
-
-EXPORT_INTERVAL_MILLIS = 60_000
 
 # Keyed on the SDK instrument class (the API class raises at reader construction), so the
 # process gauges keep their default aggregation and temporality
@@ -30,21 +29,31 @@ SYSTEM_METRICS_CONFIG: dict[str, list[str] | None] = {
 }
 
 
-class ApitallyMetricReader(PeriodicExportingMetricReader):
-    def __init__(self, exporter: MetricExporter, export_interval_millis: float | None = None) -> None:
-        super().__init__(exporter, export_interval_millis=export_interval_millis)
-        # MeterProvider's atexit hook misses readers added via add_metric_reader
-        atexit.register(self.shutdown)
+class ApitallyMetricReader(MetricReader):
+    """Non-periodic reader without a timer thread: the export worker drives collection
+    every export cycle, so all three signals leave in lockstep. Collected metrics are
+    encoded to protobuf and appended to the spool."""
+
+    def __init__(self, spool: Spool) -> None:
+        super().__init__(
+            preferred_temporality=HISTOGRAM_PREFERRED_TEMPORALITY,
+            preferred_aggregation=HISTOGRAM_PREFERRED_AGGREGATION,
+        )
+        self.spool = spool
 
     def collect(self, timeout_millis: float = 10_000) -> None:  # ty: ignore[override-of-final-method]
-        # After the reader is detached, _collect is None; a last collect from the reader's
-        # export timer thread must do nothing instead of logging a not-registered warning
+        # After the reader is detached, _collect is None; a collect must do nothing
+        # instead of logging a not-registered warning
         if self._collect is not None:
             super().collect(timeout_millis=timeout_millis)
 
+    def _receive_metrics(self, metrics_data: MetricsData, timeout_millis: float = 10_000, **kwargs: Any) -> None:
+        if metrics_data is None or not metrics_data.resource_metrics:  # pragma: no cover
+            return
+        self.spool.append("metrics", encode_metrics(metrics_data).SerializeToString())
+
     def shutdown(self, timeout_millis: float = 30_000, **kwargs: Any) -> None:
-        atexit.unregister(self.shutdown)
-        super().shutdown(timeout_millis=timeout_millis, **kwargs)
+        pass
 
 
 meter_provider: MeterProvider | None = None
@@ -53,10 +62,6 @@ request_duration: Histogram | None = None
 request_body_size: Histogram | None = None
 response_body_size: Histogram | None = None
 start_time: float = 0.0
-
-# OTel's fork handlers hold weak references to readers; keep detached instances
-# alive to avoid unraisable noise on a later fork
-detached_readers: list[ApitallyMetricReader] = []
 
 
 def setup(resource: Resource) -> MeterProvider:
@@ -108,17 +113,12 @@ def record_request(
         response_body_size.record(response_size, attributes)
 
 
-def attach_reader(env: str) -> None:
+def attach_reader(spool: Spool) -> None:
     global reader
     if meter_provider is None:  # pragma: no cover
         return
     detach_reader()
-    exporter = create_metric_exporter(
-        env,
-        preferred_temporality=HISTOGRAM_PREFERRED_TEMPORALITY,
-        preferred_aggregation=HISTOGRAM_PREFERRED_AGGREGATION,
-    )
-    reader = ApitallyMetricReader(exporter, export_interval_millis=EXPORT_INTERVAL_MILLIS)
+    reader = ApitallyMetricReader(spool)
     meter_provider.add_metric_reader(reader)
 
 
@@ -126,7 +126,6 @@ def detach_reader() -> None:
     global reader
     if meter_provider is not None and reader is not None:
         meter_provider.remove_metric_reader(reader)
-        detached_readers.append(reader)
         reader = None
 
 

--- a/apitally/shared/metrics.py
+++ b/apitally/shared/metrics.py
@@ -31,8 +31,7 @@ SYSTEM_METRICS_CONFIG: dict[str, list[str] | None] = {
 
 class ApitallyMetricReader(MetricReader):
     """Non-periodic reader without a timer thread: the export worker drives collection
-    every export cycle, so all three signals leave in lockstep. Collected metrics are
-    encoded to protobuf and appended to the spool."""
+    every export cycle, so all three signals export in lockstep."""
 
     def __init__(self, spool: Spool) -> None:
         super().__init__(
@@ -42,8 +41,6 @@ class ApitallyMetricReader(MetricReader):
         self.spool = spool
 
     def collect(self, timeout_millis: float = 10_000) -> None:  # ty: ignore[override-of-final-method]
-        # After the reader is detached, _collect is None; a collect must do nothing
-        # instead of logging a not-registered warning
         if self._collect is not None:
             super().collect(timeout_millis=timeout_millis)
 

--- a/apitally/shared/providers.py
+++ b/apitally/shared/providers.py
@@ -5,13 +5,9 @@ from importlib.metadata import PackageNotFoundError, version
 from typing import cast
 
 from opentelemetry import trace
-from opentelemetry.exporter.otlp.proto.http._log_exporter import OTLPLogExporter
-from opentelemetry.exporter.otlp.proto.http.metric_exporter import OTLPMetricExporter
-from opentelemetry.exporter.otlp.proto.http.trace_exporter import OTLPSpanExporter
 from opentelemetry.sdk._logs import LoggerProvider, LogRecordProcessor
 from opentelemetry.sdk.metrics import MeterProvider
-from opentelemetry.sdk.metrics.export import AggregationTemporality, MetricReader
-from opentelemetry.sdk.metrics.view import Aggregation
+from opentelemetry.sdk.metrics.export import MetricReader
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanLimits, SpanProcessor, TracerProvider
 from opentelemetry.sdk.trace.sampling import ALWAYS_OFF, ALWAYS_ON, ParentBased, Sampler, TraceIdRatioBased
@@ -108,27 +104,6 @@ def create_logger_provider(resource: Resource, processors: Sequence[LogRecordPro
     for processor in processors:
         provider.add_log_record_processor(processor)
     return provider
-
-
-def create_span_exporter(env: str) -> OTLPSpanExporter:
-    return OTLPSpanExporter(endpoint=endpoint_url("/v1/traces"), headers=export_headers(env))
-
-
-def create_metric_exporter(
-    env: str,
-    preferred_temporality: dict[type, AggregationTemporality] | None = None,
-    preferred_aggregation: dict[type, Aggregation] | None = None,
-) -> OTLPMetricExporter:
-    return OTLPMetricExporter(
-        endpoint=endpoint_url("/v1/metrics"),
-        headers=export_headers(env),
-        preferred_temporality=preferred_temporality,
-        preferred_aggregation=preferred_aggregation,
-    )
-
-
-def create_log_exporter(env: str) -> OTLPLogExporter:
-    return OTLPLogExporter(endpoint=endpoint_url("/v1/logs"), headers=export_headers(env))
 
 
 def reset() -> None:

--- a/apitally/shared/spool.py
+++ b/apitally/shared/spool.py
@@ -148,6 +148,12 @@ class Spool:
                     self._rotate_locked(signal)
             self._evict_locked()
 
+    def close_current_files(self) -> None:
+        """Close every signal's current file so no gzip writer is open across a fork."""
+        with self.lock:
+            for signal in list(self.current):
+                self._rotate_locked(signal)
+
     def pending_files(self) -> list[SpoolFile]:
         """Closed files in send order (oldest first)."""
         with self.lock:

--- a/apitally/shared/spool.py
+++ b/apitally/shared/spool.py
@@ -1,5 +1,3 @@
-from __future__ import annotations
-
 import gzip
 import logging
 import os
@@ -16,38 +14,11 @@ logger = logging.getLogger(__name__)
 
 SIGNALS = ("traces", "logs", "metrics")
 
-ROTATE_AT_UNCOMPRESSED_SIZE = 4_000_000
+MAX_UNCOMPRESSED_FILE_SIZE = 4_000_000
 MAX_SPOOL_SIZE_DISK = 50_000_000
 MAX_SPOOL_SIZE_MEMORY = 10_000_000
-# A file whose first send attempt might have been published server-side must not be re-sent
-# after the server's 1h dedup window; one minute of margin covers transit time and timeouts
-SEND_HORIZON = 59 * 60
-ORPHAN_MAX_AGE = 2 * 60 * 60
-
-
-class DuplicateLogFilter(logging.Filter):
-    """Drops repeats of the same message within a time window, so a persistently failing
-    export path cannot log endlessly."""
-
-    def __init__(self, window_seconds: float = 60.0) -> None:
-        super().__init__()
-        self.window_seconds = window_seconds
-        self.last_logged: dict[tuple[str, int, str], float] = {}
-
-    def filter(self, record: logging.LogRecord) -> bool:
-        # Keyed on the rendered message, not the template, so warnings that differ only
-        # in their arguments (e.g. per-signal data loss) are not swallowed
-        key = (record.module, record.levelno, record.getMessage())
-        now = time.time()
-        last = self.last_logged.get(key)
-        if last is not None and now - last < self.window_seconds:
-            return False
-        self.last_logged[key] = now
-        return True
-
-
-duplicate_log_filter = DuplicateLogFilter()
-logger.addFilter(duplicate_log_filter)
+MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT = 59 * 60
+MAX_UNTOUCHED_FILE_AGE = 2 * 60 * 60
 
 
 class SpoolFile:
@@ -64,7 +35,7 @@ class SpoolFile:
             self.sink: IO[bytes] = BytesIO()
         else:
             file = tempfile.NamedTemporaryFile(prefix="apitally-", suffix=".gz", delete=False)
-            self.sink = cast("IO[bytes]", file)
+            self.sink = cast(IO[bytes], file)
             self.path = Path(file.name)
         self.gzip_stream = gzip.GzipFile(fileobj=self.sink, mode="wb")
 
@@ -73,27 +44,19 @@ class SpoolFile:
         self.uncompressed_size += len(payload)
 
     def close(self) -> None:
-        # The sink stays open so the bytes remain readable even if another process sweeps
-        # the path. The flush moves the compressed bytes out of the Python-level buffer
-        # onto disk; without it, a closed file shares its unwritten tail with a forked
-        # child through the inherited file descriptor, and both processes flushing it
-        # corrupts the file
         self.gzip_stream.close()
         self.sink.flush()
         self.compressed_size = self.sink.tell()
 
-    def read_bytes(self) -> bytes:
-        self.sink.seek(0)
-        return self.sink.read()
-
     def mark_attempt(self) -> None:
-        # Monotonic clock: a wall-clock step backwards must not extend retries past the
-        # server's dedup window
         if self.first_attempt_at is None:
             self.first_attempt_at = time.monotonic()
 
-    def expired(self) -> bool:
-        return self.first_attempt_at is not None and time.monotonic() - self.first_attempt_at > SEND_HORIZON
+    def is_expired(self) -> bool:
+        return (
+            self.first_attempt_at is not None
+            and time.monotonic() - self.first_attempt_at > MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT
+        )
 
     def touch(self) -> None:
         if self.path is not None:
@@ -111,12 +74,11 @@ class SpoolFile:
 
 
 class Spool:
-    """Byte spool between the batch processors and the export worker: accepts serialized
-    payloads per signal, manages file rotation, caps and eviction. Thread-safe; appends
+    """Byte spool between the batch processors and the export worker. Thread-safe: appends
     come from the batch worker threads, rotation and sending from the export worker."""
 
     def __init__(self) -> None:
-        self.in_memory = not check_writable_fs()
+        self.in_memory = not is_temp_dir_writable()
         if self.in_memory:
             logger.warning(
                 "Unable to create temporary files, buffering telemetry in memory (max %d MB)",
@@ -132,8 +94,8 @@ class Spool:
     def append(self, signal: str, payload: bytes) -> None:
         with self.lock:
             current = self.current.get(signal)
-            if current is not None and current.uncompressed_size + len(payload) > ROTATE_AT_UNCOMPRESSED_SIZE:
-                self._rotate_locked(signal)
+            if current is not None and current.uncompressed_size + len(payload) > MAX_UNCOMPRESSED_FILE_SIZE:
+                self.rotate_locked(signal)
                 current = None
             try:
                 if current is None:
@@ -142,24 +104,22 @@ class Spool:
                 current.write(payload)
             except OSError:
                 logger.warning("Error writing telemetry to disk, dropping buffered %s", signal, exc_info=True)
-                self._discard_current_locked(signal)
-            self._evict_locked()
+                self.discard_current_locked(signal)
+            self.evict_locked()
 
     def rotate_for_export(self) -> None:
-        """Close each signal's current file so it becomes sendable, unless the signal
-        already has closed files waiting (during a backlog the current file keeps growing
-        instead of adding one small file per cycle)."""
+        """Close each signal's current file so it becomes sendable, unless closed files are
+        already waiting (a backlog grows the current file instead of adding one per cycle)."""
         with self.lock:
             for signal in SIGNALS:
                 if signal in self.current and not any(file.signal == signal for file in self.closed):
-                    self._rotate_locked(signal)
-            self._evict_locked()
+                    self.rotate_locked(signal)
+            self.evict_locked()
 
     def close_current_files(self) -> None:
-        """Close every signal's current file so no gzip writer is open across a fork."""
         with self.lock:
             for signal in list(self.current):
-                self._rotate_locked(signal)
+                self.rotate_locked(signal)
 
     def pending_files(self) -> list[SpoolFile]:
         """Closed files in send order (oldest first)."""
@@ -173,22 +133,21 @@ class Spool:
             file.delete()
 
     def touch_files(self) -> None:
-        """Refresh mtimes so sibling processes' orphan sweeps never touch live files."""
+        """Refresh mtimes so cleanup_orphaned_files in a sibling process never removes live files."""
         with self.lock:
             for file in (*self.current.values(), *self.closed):
                 file.touch()
 
     def clear(self) -> None:
-        """Teardown for tests and reset. The spool never deletes files from a finalizer,
-        so a forked child can safely abandon an inherited instance."""
+        """Teardown for tests and reset."""
         with self.lock:
             for signal in list(self.current):
-                self._discard_current_locked(signal)
+                self.discard_current_locked(signal)
             for file in self.closed:
                 file.delete()
             self.closed.clear()
 
-    def _rotate_locked(self, signal: str) -> None:
+    def rotate_locked(self, signal: str) -> None:
         current = self.current.pop(signal, None)
         if current is None:
             return
@@ -200,33 +159,32 @@ class Spool:
             return
         self.closed.append(current)
 
-    def _discard_current_locked(self, signal: str) -> None:
+    def discard_current_locked(self, signal: str) -> None:
         current = self.current.pop(signal, None)
         if current is not None:
             current.delete()
 
-    def _evict_locked(self) -> None:
-        for file in [file for file in self.closed if file.expired()]:
+    def evict_locked(self) -> None:
+        for file in [file for file in self.closed if file.is_expired()]:
             logger.warning("Buffered %s could not be delivered within an hour and was dropped", file.signal)
             self.closed.remove(file)
             file.delete()
-        while self._total_size_locked() > self.max_size:
-            # Metrics files are exempt: a full hour of metric payloads is small, and the
-            # aggregate data is the primary value that must survive an outage
+        while self.total_size_locked() > self.max_size:
+            # Metrics are exempt: an hour of them is small and they must survive an outage
             oldest = next((file for file in self.closed if file.signal != "metrics"), None)
             if oldest is None:
                 break
-            logger.warning("Apitally buffer size limit reached, dropping oldest buffered %s", oldest.signal)
+            logger.warning("Buffer size limit reached, dropping oldest buffered %s", oldest.signal)
             self.closed.remove(oldest)
             oldest.delete()
 
-    def _total_size_locked(self) -> int:
+    def total_size_locked(self) -> int:
         return sum(file.compressed_size for file in self.closed) + sum(
             file.sink.tell() for file in self.current.values()
         )
 
 
-def check_writable_fs() -> bool:
+def is_temp_dir_writable() -> bool:
     try:
         with tempfile.NamedTemporaryFile(prefix="apitally-"):
             return True
@@ -236,8 +194,8 @@ def check_writable_fs() -> bool:
 
 def cleanup_orphaned_files() -> None:
     """Best-effort removal of spool files left behind by crashed processes. Live processes
-    shield their files by touching them every export cycle."""
-    cutoff = time.time() - ORPHAN_MAX_AGE
+    refresh their files' mtimes every export cycle, keeping them newer than the cutoff."""
+    cutoff = time.time() - MAX_UNTOUCHED_FILE_AGE
     with suppress(OSError):
         for path in Path(tempfile.gettempdir()).glob("apitally-*.gz"):
             with suppress(OSError):

--- a/apitally/shared/spool.py
+++ b/apitally/shared/spool.py
@@ -35,7 +35,9 @@ class DuplicateLogFilter(logging.Filter):
         self.last_logged: dict[tuple[str, int, str], float] = {}
 
     def filter(self, record: logging.LogRecord) -> bool:
-        key = (record.module, record.levelno, record.msg)
+        # Keyed on the rendered message, not the template, so warnings that differ only
+        # in their arguments (e.g. per-signal data loss) are not swallowed
+        key = (record.module, record.levelno, record.getMessage())
         now = time.time()
         last = self.last_logged.get(key)
         if last is not None and now - last < self.window_seconds:
@@ -72,9 +74,13 @@ class SpoolFile:
         self.uncompressed_size += len(payload)
 
     def close(self) -> None:
-        # Flushes the gzip trailer; the sink stays open so the bytes remain readable even
-        # if another process sweeps the path
+        # The sink stays open so the bytes remain readable even if another process sweeps
+        # the path. The flush moves the compressed bytes out of the Python-level buffer
+        # onto disk; without it, a closed file shares its unwritten tail with a forked
+        # child through the inherited file descriptor, and both processes flushing it
+        # corrupts the file
         self.gzip_stream.close()
+        self.sink.flush()
         self.compressed_size = self.sink.tell()
 
     def read_bytes(self) -> bytes:
@@ -82,11 +88,13 @@ class SpoolFile:
         return self.sink.read()
 
     def mark_attempt(self) -> None:
+        # Monotonic clock: a wall-clock step backwards must not extend retries past the
+        # server's dedup window
         if self.first_attempt_at is None:
-            self.first_attempt_at = time.time()
+            self.first_attempt_at = time.monotonic()
 
     def expired(self) -> bool:
-        return self.first_attempt_at is not None and time.time() - self.first_attempt_at > SEND_HORIZON
+        return self.first_attempt_at is not None and time.monotonic() - self.first_attempt_at > SEND_HORIZON
 
     def touch(self) -> None:
         if self.path is not None:

--- a/apitally/shared/spool.py
+++ b/apitally/shared/spool.py
@@ -148,9 +148,7 @@ class Spool:
             self.closed.clear()
 
     def rotate_locked(self, signal: str) -> None:
-        current = self.current.pop(signal, None)
-        if current is None:
-            return
+        current = self.current.pop(signal)
         try:
             current.close()
         except OSError:

--- a/apitally/shared/spool.py
+++ b/apitally/shared/spool.py
@@ -56,7 +56,6 @@ class SpoolFile:
 
     def __init__(self, signal: str, in_memory: bool) -> None:
         self.signal = signal
-        self.created_at = time.time()
         self.first_attempt_at: float | None = None
         self.uncompressed_size = 0
         self.compressed_size = 0

--- a/apitally/shared/spool.py
+++ b/apitally/shared/spool.py
@@ -1,0 +1,232 @@
+from __future__ import annotations
+
+import gzip
+import logging
+import os
+import tempfile
+import threading
+import time
+from contextlib import suppress
+from io import BytesIO
+from pathlib import Path
+from typing import IO, cast
+
+
+logger = logging.getLogger(__name__)
+
+SIGNALS = ("traces", "logs", "metrics")
+
+ROTATE_AT_UNCOMPRESSED_SIZE = 4_000_000
+MAX_SPOOL_SIZE_DISK = 50_000_000
+MAX_SPOOL_SIZE_MEMORY = 10_000_000
+# A file whose first send attempt might have been published server-side must not be re-sent
+# after the server's 1h dedup window; one minute of margin covers transit time and timeouts
+SEND_HORIZON = 59 * 60
+ORPHAN_MAX_AGE = 2 * 60 * 60
+
+
+class DuplicateLogFilter(logging.Filter):
+    """Drops repeats of the same message within a time window, so a persistently failing
+    export path cannot log endlessly."""
+
+    def __init__(self, window_seconds: float = 60.0) -> None:
+        super().__init__()
+        self.window_seconds = window_seconds
+        self.last_logged: dict[tuple[str, int, str], float] = {}
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        key = (record.module, record.levelno, record.msg)
+        now = time.time()
+        last = self.last_logged.get(key)
+        if last is not None and now - last < self.window_seconds:
+            return False
+        self.last_logged[key] = now
+        return True
+
+
+duplicate_log_filter = DuplicateLogFilter()
+logger.addFilter(duplicate_log_filter)
+
+
+class SpoolFile:
+    """One gzip stream of concatenated OTLP request payloads for a single signal, written
+    over a temp file or, as fallback, an in-memory buffer."""
+
+    def __init__(self, signal: str, in_memory: bool) -> None:
+        self.signal = signal
+        self.created_at = time.time()
+        self.first_attempt_at: float | None = None
+        self.uncompressed_size = 0
+        self.compressed_size = 0
+        self.path: Path | None = None
+        if in_memory:
+            self.sink: IO[bytes] = BytesIO()
+        else:
+            file = tempfile.NamedTemporaryFile(prefix="apitally-", suffix=".gz", delete=False)
+            self.sink = cast("IO[bytes]", file)
+            self.path = Path(file.name)
+        self.gzip_stream = gzip.GzipFile(fileobj=self.sink, mode="wb")
+
+    def write(self, payload: bytes) -> None:
+        self.gzip_stream.write(payload)
+        self.uncompressed_size += len(payload)
+
+    def close(self) -> None:
+        # Flushes the gzip trailer; the sink stays open so the bytes remain readable even
+        # if another process sweeps the path
+        self.gzip_stream.close()
+        self.compressed_size = self.sink.tell()
+
+    def read_bytes(self) -> bytes:
+        self.sink.seek(0)
+        return self.sink.read()
+
+    def mark_attempt(self) -> None:
+        if self.first_attempt_at is None:
+            self.first_attempt_at = time.time()
+
+    def expired(self) -> bool:
+        return self.first_attempt_at is not None and time.time() - self.first_attempt_at > SEND_HORIZON
+
+    def touch(self) -> None:
+        if self.path is not None:
+            with suppress(OSError):
+                os.utime(self.path)
+
+    def delete(self) -> None:
+        with suppress(OSError, ValueError):
+            self.gzip_stream.close()
+        with suppress(OSError):
+            self.sink.close()
+        if self.path is not None:
+            with suppress(OSError):
+                self.path.unlink(missing_ok=True)
+
+
+class Spool:
+    """Byte spool between the batch processors and the export worker: accepts serialized
+    payloads per signal, manages file rotation, caps and eviction. Thread-safe; appends
+    come from the batch worker threads, rotation and sending from the export worker."""
+
+    def __init__(self) -> None:
+        self.in_memory = not check_writable_fs()
+        if self.in_memory:
+            logger.warning(
+                "Unable to create temporary files, buffering telemetry in memory (max %d MB)",
+                MAX_SPOOL_SIZE_MEMORY // 1_000_000,
+            )
+        else:
+            cleanup_orphaned_files()
+        self.max_size = MAX_SPOOL_SIZE_MEMORY if self.in_memory else MAX_SPOOL_SIZE_DISK
+        self.lock = threading.Lock()
+        self.current: dict[str, SpoolFile] = {}
+        self.closed: list[SpoolFile] = []
+
+    def append(self, signal: str, payload: bytes) -> None:
+        with self.lock:
+            current = self.current.get(signal)
+            if current is not None and current.uncompressed_size + len(payload) > ROTATE_AT_UNCOMPRESSED_SIZE:
+                self._rotate_locked(signal)
+                current = None
+            try:
+                if current is None:
+                    current = SpoolFile(signal, self.in_memory)
+                    self.current[signal] = current
+                current.write(payload)
+            except OSError:
+                logger.warning("Error writing telemetry to disk, dropping buffered %s", signal, exc_info=True)
+                self._discard_current_locked(signal)
+            self._evict_locked()
+
+    def rotate_for_export(self) -> None:
+        """Close each signal's current file so it becomes sendable, unless the signal
+        already has closed files waiting (during a backlog the current file keeps growing
+        instead of adding one small file per cycle)."""
+        with self.lock:
+            for signal in SIGNALS:
+                if signal in self.current and not any(file.signal == signal for file in self.closed):
+                    self._rotate_locked(signal)
+            self._evict_locked()
+
+    def pending_files(self) -> list[SpoolFile]:
+        """Closed files in send order (oldest first)."""
+        with self.lock:
+            return list(self.closed)
+
+    def delete_file(self, file: SpoolFile) -> None:
+        with self.lock:
+            if file in self.closed:
+                self.closed.remove(file)
+            file.delete()
+
+    def touch_files(self) -> None:
+        """Refresh mtimes so sibling processes' orphan sweeps never touch live files."""
+        with self.lock:
+            for file in (*self.current.values(), *self.closed):
+                file.touch()
+
+    def clear(self) -> None:
+        """Teardown for tests and reset. The spool never deletes files from a finalizer,
+        so a forked child can safely abandon an inherited instance."""
+        with self.lock:
+            for signal in list(self.current):
+                self._discard_current_locked(signal)
+            for file in self.closed:
+                file.delete()
+            self.closed.clear()
+
+    def _rotate_locked(self, signal: str) -> None:
+        current = self.current.pop(signal, None)
+        if current is None:
+            return
+        try:
+            current.close()
+        except OSError:
+            logger.warning("Error writing telemetry to disk, dropping buffered %s", signal, exc_info=True)
+            current.delete()
+            return
+        self.closed.append(current)
+
+    def _discard_current_locked(self, signal: str) -> None:
+        current = self.current.pop(signal, None)
+        if current is not None:
+            current.delete()
+
+    def _evict_locked(self) -> None:
+        for file in [file for file in self.closed if file.expired()]:
+            logger.warning("Buffered %s could not be delivered within an hour and was dropped", file.signal)
+            self.closed.remove(file)
+            file.delete()
+        while self._total_size_locked() > self.max_size:
+            # Metrics files are exempt: a full hour of metric payloads is small, and the
+            # aggregate data is the primary value that must survive an outage
+            oldest = next((file for file in self.closed if file.signal != "metrics"), None)
+            if oldest is None:
+                break
+            logger.warning("Apitally buffer size limit reached, dropping oldest buffered %s", oldest.signal)
+            self.closed.remove(oldest)
+            oldest.delete()
+
+    def _total_size_locked(self) -> int:
+        return sum(file.compressed_size for file in self.closed) + sum(
+            file.sink.tell() for file in self.current.values()
+        )
+
+
+def check_writable_fs() -> bool:
+    try:
+        with tempfile.NamedTemporaryFile(prefix="apitally-"):
+            return True
+    except OSError:
+        return False
+
+
+def cleanup_orphaned_files() -> None:
+    """Best-effort removal of spool files left behind by crashed processes. Live processes
+    shield their files by touching them every export cycle."""
+    cutoff = time.time() - ORPHAN_MAX_AGE
+    with suppress(OSError):
+        for path in Path(tempfile.gettempdir()).glob("apitally-*.gz"):
+            with suppress(OSError):
+                if path.stat().st_mtime < cutoff:
+                    path.unlink()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,8 @@ requires-python = ">=3.10,<4.0"
 dependencies = [
     "opentelemetry-api>=1.43.0,<2.0.0",
     "opentelemetry-sdk>=1.43.0,<2.0.0",
-    "opentelemetry-exporter-otlp-proto-http>=1.43.0,<2.0.0",
+    "opentelemetry-exporter-otlp-proto-common>=1.43.0,<2.0.0",
+    "requests>=2.26.0",
     "opentelemetry-instrumentation>=0.64b0",
     "opentelemetry-instrumentation-logging>=0.64b0",
     "opentelemetry-instrumentation-system-metrics>=0.64b0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -144,7 +144,7 @@ build-backend = "hatchling.build"
 source = "vcs"
 
 [tool.uv]
-default-groups = ["dev", "test", "types"]
+default-groups = "all"
 
 [tool.ruff]
 line-length = 120

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,7 +34,7 @@ from apitally.shared.span_processor import (
     server_span_processor_var,
     server_span_var,
 )
-from apitally.shared.spool import Spool
+from apitally.shared.spool import Spool, SpoolFile
 
 
 WRITE_TOKEN = "apt_" + "a" * 24
@@ -51,6 +51,11 @@ _T = TypeVar("_T")
 def unwrap(value: _T | None) -> _T:
     assert value is not None
     return value
+
+
+def read_spool_file(file: SpoolFile) -> bytes:
+    file.sink.seek(0)
+    return file.sink.read()
 
 
 # Skip collection of framework test modules whose framework or instrumentor is not installed,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,9 @@
 import json
 import os
-from collections.abc import Iterator
+import threading
+from collections.abc import Callable, Iterator
 from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from importlib.util import find_spec
 from typing import Any, TypeVar
 
@@ -15,9 +17,6 @@ from opentelemetry.sdk.metrics.export import (
     ExponentialHistogramDataPoint,
     InMemoryMetricReader,
     Metric,
-    MetricExporter,
-    MetricExportResult,
-    MetricsData,
 )
 from opentelemetry.sdk.trace import ReadableSpan, TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor, SpanExporter
@@ -26,7 +25,7 @@ from opentelemetry.sdk.trace.sampling import ALWAYS_ON, Sampler
 from opentelemetry.test.globals_test import reset_trace_globals
 from opentelemetry.trace import SpanKind, Tracer
 
-from apitally.shared import activation, config, metrics, providers, startup
+from apitally.shared import activation, config, export, metrics, providers, startup
 from apitally.shared.consumer import consumer_holder_var
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.span_processor import (
@@ -35,6 +34,7 @@ from apitally.shared.span_processor import (
     server_span_processor_var,
     server_span_var,
 )
+from apitally.shared.spool import Spool
 
 
 WRITE_TOKEN = "apt_" + "a" * 24
@@ -115,48 +115,74 @@ def reset_context_vars() -> Iterator[None]:
     consumer_holder_var.set(None)
 
 
-class InMemoryMetricExporter(MetricExporter):
-    def export(self, metrics_data: MetricsData, timeout_millis: float = 10_000, **kwargs: Any) -> MetricExportResult:
-        return MetricExportResult.SUCCESS
-
-    def shutdown(self, timeout_millis: float = 30_000, **kwargs: Any) -> None:
-        pass
-
-    def force_flush(self, timeout_millis: float = 10_000) -> bool:
-        return True
-
-
 @dataclass
 class InMemoryExporters:
     span: list[InMemorySpanExporter] = field(default_factory=list)
     log: list[InMemoryLogRecordExporter] = field(default_factory=list)
-    metric: list[InMemoryMetricExporter] = field(default_factory=list)
 
 
 @pytest.fixture
 def exporters(monkeypatch: pytest.MonkeyPatch) -> InMemoryExporters:
-    """Replace the OTLP exporter factories so activation never constructs network exporters."""
+    """Replace the spool exporter factories with in-memory exporters and keep the export
+    worker thread from starting, so activation never performs network I/O."""
     created = InMemoryExporters()
 
-    def span_exporter(env: str) -> InMemorySpanExporter:
+    def span_exporter(spool: Spool) -> InMemorySpanExporter:
         exporter = InMemorySpanExporter()
         created.span.append(exporter)
         return exporter
 
-    def log_exporter(env: str) -> InMemoryLogRecordExporter:
+    def log_exporter(spool: Spool) -> InMemoryLogRecordExporter:
         exporter = InMemoryLogRecordExporter()
         created.log.append(exporter)
         return exporter
 
-    def metric_exporter(env: str, **kwargs: Any) -> InMemoryMetricExporter:
-        exporter = InMemoryMetricExporter(**kwargs)
-        created.metric.append(exporter)
-        return exporter
-
-    monkeypatch.setattr(providers, "create_span_exporter", span_exporter)
-    monkeypatch.setattr(providers, "create_log_exporter", log_exporter)
-    monkeypatch.setattr(metrics, "create_metric_exporter", metric_exporter)
+    monkeypatch.setattr(export, "create_span_exporter", span_exporter)
+    monkeypatch.setattr(export, "create_log_exporter", log_exporter)
+    monkeypatch.setattr(export.ExportWorker, "start", lambda self: None)
     return created
+
+
+class StubOTLPServer:
+    """Local HTTP server recording POSTed requests, with scriptable responses per path."""
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict[str, str], bytes]] = []
+        self.respond: Callable[[str], tuple[int, dict[str, str]]] = lambda path: (200, {})
+        stub = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                stub.requests.append((self.path, dict(self.headers), body))
+                status, headers = stub.respond(self.path)
+                self.send_response(status)
+                for key, value in headers.items():
+                    self.send_header(key, value)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, format: str, *args: Any) -> None:
+                pass
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def paths(self) -> list[str]:
+        return [path for path, _, _ in self.requests]
+
+
+@pytest.fixture
+def otlp_server() -> Iterator[StubOTLPServer]:
+    stub = StubOTLPServer()
+    yield stub
+    stub.server.shutdown()
+    stub.server.server_close()
 
 
 def attach_metric_reader(provider: MeterProvider | None = None) -> InMemoryMetricReader:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,4 @@
+import gzip
 import json
 import os
 import threading
@@ -53,9 +54,10 @@ def unwrap(value: _T | None) -> _T:
     return value
 
 
-def read_spool_file(file: SpoolFile) -> bytes:
+def read_spool_payload(file: SpoolFile) -> bytes:
+    """Decompressed concatenation of the OTLP payloads appended to a spool file."""
     file.sink.seek(0)
-    return file.sink.read()
+    return gzip.decompress(file.sink.read())
 
 
 # Skip collection of framework test modules whose framework or instrumentor is not installed,

--- a/tests/shared/test_activation.py
+++ b/tests/shared/test_activation.py
@@ -22,7 +22,7 @@ from opentelemetry.trace import SpanKind
 from apitally.shared import activation, export, log_processor, metrics
 from apitally.shared.asgi import Message, Receive, Scope, Send
 from apitally.shared.span_processor import ApitallySpanProcessor
-from tests.conftest import WRITE_TOKEN, InMemoryExporters, StubOTLPServer, exported_spans, read_spool_file, unwrap
+from tests.conftest import WRITE_TOKEN, InMemoryExporters, StubOTLPServer, exported_spans, unwrap
 
 
 if TYPE_CHECKING:
@@ -310,7 +310,7 @@ def test_fork_in_child_abandons_inherited_spool_without_touching_parent_files(
         activation.before_fork()
         files = parent_spool.pending_files()
         assert files
-        bytes_before = {unwrap(file.path): read_spool_file(file) for file in files}
+        bytes_before = {unwrap(file.path): unwrap(file.path).read_bytes() for file in files}
 
         activation.after_fork_in_child()
         assert activation.spool is None

--- a/tests/shared/test_activation.py
+++ b/tests/shared/test_activation.py
@@ -22,7 +22,7 @@ from opentelemetry.trace import SpanKind
 from apitally.shared import activation, export, log_processor, metrics
 from apitally.shared.asgi import Message, Receive, Scope, Send
 from apitally.shared.span_processor import ApitallySpanProcessor
-from tests.conftest import WRITE_TOKEN, InMemoryExporters, StubOTLPServer, exported_spans, unwrap
+from tests.conftest import WRITE_TOKEN, InMemoryExporters, StubOTLPServer, exported_spans, read_spool_file, unwrap
 
 
 if TYPE_CHECKING:
@@ -290,8 +290,7 @@ def test_after_fork_in_parent_restarts_worker_and_delivers_prefork_files(
     while time.time() < deadline and not postfork_metric_received():
         time.sleep(0.02)
     assert "/v1/traces" in otlp_server.paths()
-    # A post-fork metrics payload proves the worker resolves the fresh reader, not the
-    # detached one, whose collect would be a no-op
+    # Proves the worker resolves the fresh reader; the detached one's collect is a no-op
     assert postfork_metric_received()
     metric_bodies = [body for path, _, body in otlp_server.requests if path == "/v1/metrics"]
     assert ExportMetricsServiceRequest.FromString(gzip.decompress(metric_bodies[-1]))
@@ -311,7 +310,7 @@ def test_fork_in_child_abandons_inherited_spool_without_touching_parent_files(
         activation.before_fork()
         files = parent_spool.pending_files()
         assert files
-        bytes_before = {unwrap(file.path): file.read_bytes() for file in files}
+        bytes_before = {unwrap(file.path): read_spool_file(file) for file in files}
 
         activation.after_fork_in_child()
         assert activation.spool is None

--- a/tests/shared/test_activation.py
+++ b/tests/shared/test_activation.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import gc
+import gzip
 import multiprocessing
 import os
 import sys
@@ -10,16 +12,17 @@ from typing import TYPE_CHECKING, Any
 
 import pytest
 from opentelemetry import trace
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
 from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import TracerProvider
 from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind
 
-from apitally.shared import activation, log_processor, metrics, providers
+from apitally.shared import activation, export, log_processor, metrics
 from apitally.shared.asgi import Message, Receive, Scope, Send
 from apitally.shared.span_processor import ApitallySpanProcessor
-from tests.conftest import WRITE_TOKEN, InMemoryExporters, exported_spans
+from tests.conftest import WRITE_TOKEN, InMemoryExporters, StubOTLPServer, exported_spans, unwrap
 
 
 if TYPE_CHECKING:
@@ -126,9 +129,8 @@ def test_wsgi_shim_activates_before_first_request_proceeds(
 @pytest.mark.parametrize("guard", ["pytest_env", "manage_py_test", "disabled_env", "disabled_kwarg"])
 def test_test_environment_guard_skips_activation(monkeypatch: pytest.MonkeyPatch, guard: str):
     exporter_calls = []
-    monkeypatch.setattr(providers, "create_span_exporter", lambda env: exporter_calls.append("span"))
-    monkeypatch.setattr(providers, "create_log_exporter", lambda env: exporter_calls.append("log"))
-    monkeypatch.setattr(metrics, "create_metric_exporter", lambda env, **kwargs: exporter_calls.append("metric"))
+    monkeypatch.setattr(export, "create_span_exporter", lambda spool: exporter_calls.append("span"))
+    monkeypatch.setattr(export, "create_log_exporter", lambda spool: exporter_calls.append("log"))
 
     activation.configure(write_token=WRITE_TOKEN, disabled=(guard == "disabled_kwarg"))
     if guard != "pytest_env":
@@ -254,6 +256,98 @@ def test_child_reactivation_clears_inherited_request_state(
     assert not activation.span_processor.pending
     span.end()
     assert exporters.span[-1].get_finished_spans() == ()
+
+
+def test_after_fork_in_parent_restarts_worker_and_delivers_prefork_files(
+    otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 60.0)
+    activation.configure(write_token=WRITE_TOKEN, otlp_endpoint=otlp_server.url)
+    activation.activate()
+    with trace.get_tracer("test").start_as_current_span("GET /prefork", kind=SpanKind.SERVER):
+        pass
+
+    activation.before_fork()
+    worker = unwrap(activation.export_worker)
+    assert unwrap(worker.thread).is_alive() is False
+    spool = unwrap(activation.spool)
+    assert any(file.signal == "traces" for file in spool.pending_files())
+
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 0.05)
+    worker.interval = 0.2
+    activation.after_fork_in_parent()
+    assert unwrap(worker.thread).is_alive()
+    metrics.record_request("GET", "/postfork", 200, consumer=None, duration=0.1)
+
+    def postfork_metric_received() -> bool:
+        for path, _, body in otlp_server.requests:
+            if path == "/v1/metrics" and b"/postfork" in gzip.decompress(body):
+                return True
+        return False
+
+    deadline = time.time() + 10
+    while time.time() < deadline and not postfork_metric_received():
+        time.sleep(0.02)
+    assert "/v1/traces" in otlp_server.paths()
+    # A post-fork metrics payload proves the worker resolves the fresh reader, not the
+    # detached one, whose collect would be a no-op
+    assert postfork_metric_received()
+    metric_bodies = [body for path, _, body in otlp_server.requests if path == "/v1/metrics"]
+    assert ExportMetricsServiceRequest.FromString(gzip.decompress(metric_bodies[-1]))
+
+
+def test_fork_in_child_abandons_inherited_spool_without_touching_parent_files(
+    otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+):
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 60.0)
+    activation.configure(write_token=WRITE_TOKEN, otlp_endpoint=otlp_server.url)
+    activation.activate()
+    with trace.get_tracer("test").start_as_current_span("GET /prefork", kind=SpanKind.SERVER):
+        pass
+    parent_spool = unwrap(activation.spool)
+    try:
+        activation.before_fork()
+        files = parent_spool.pending_files()
+        assert files
+        bytes_before = {unwrap(file.path): file.read_bytes() for file in files}
+
+        activation.after_fork_in_child()
+        assert activation.spool is None
+        gc.collect()
+        for path, data in bytes_before.items():
+            with open(path, "rb") as fp:
+                assert fp.read() == data
+            assert gzip.decompress(data)
+
+        activation.activate()
+        assert unwrap(activation.spool) is not parent_spool
+        worker_threads = [
+            thread for thread in threading.enumerate() if thread.name == "ApitallyExportWorker" and thread.is_alive()
+        ]
+        assert len(worker_threads) == 1
+    finally:
+        parent_spool.clear()
+
+
+def test_reset_stops_worker_and_removes_spool_files(otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch):
+    threads_before = set(threading.enumerate())
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 60.0)
+    activation.configure(write_token=WRITE_TOKEN, otlp_endpoint=otlp_server.url)
+    activation.activate()
+    assert len(set(threading.enumerate()) - threads_before) == 3
+    with trace.get_tracer("test").start_as_current_span("GET /items", kind=SpanKind.SERVER):
+        pass
+    spool = unwrap(activation.spool)
+    unwrap(activation.span_processor).downstream.force_flush()
+    paths = [unwrap(file.path) for file in (*spool.current.values(), *spool.pending_files())]
+    assert paths
+
+    activation.reset()
+    assert not any(thread.name == "ApitallyExportWorker" and thread.is_alive() for thread in threading.enumerate())
+    assert not any(path.exists() for path in paths)
 
 
 def child_probe(queue: multiprocessing.Queue[dict[str, Any]]) -> None:

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -1,11 +1,9 @@
 import gzip
 import logging
 import socket
-import threading
 import time
 from collections import deque
-from collections.abc import Callable, Iterator
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from collections.abc import Iterator
 from types import SimpleNamespace
 from typing import Any, cast
 
@@ -39,7 +37,7 @@ from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import ApitallySpanProcessor, get_server_span_processor
 from apitally.shared.spool import SEND_HORIZON, Spool
-from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, unwrap
+from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, unwrap
 
 
 @pytest.fixture(autouse=True)
@@ -53,48 +51,6 @@ def spool() -> Iterator[Spool]:
     spool = Spool()
     yield spool
     spool.clear()
-
-
-class StubOTLPServer:
-    """Local HTTP server recording POSTed requests, with scriptable responses per path."""
-
-    def __init__(self) -> None:
-        self.requests: list[tuple[str, dict[str, str], bytes]] = []
-        self.respond: Callable[[str], tuple[int, dict[str, str]]] = lambda path: (200, {})
-        stub = self
-
-        class Handler(BaseHTTPRequestHandler):
-            def do_POST(self) -> None:
-                body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
-                stub.requests.append((self.path, dict(self.headers), body))
-                status, headers = stub.respond(self.path)
-                self.send_response(status)
-                for key, value in headers.items():
-                    self.send_header(key, value)
-                self.send_header("Content-Length", "0")
-                self.end_headers()
-
-            def log_message(self, format: str, *args: Any) -> None:
-                pass
-
-        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
-        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
-        self.thread.start()
-
-    @property
-    def url(self) -> str:
-        return f"http://127.0.0.1:{self.server.server_address[1]}"
-
-    def paths(self) -> list[str]:
-        return [path for path, _, _ in self.requests]
-
-
-@pytest.fixture
-def otlp_server() -> Iterator[StubOTLPServer]:
-    stub = StubOTLPServer()
-    yield stub
-    stub.server.shutdown()
-    stub.server.server_close()
 
 
 def make_worker(spool: Spool, endpoint: str) -> ExportWorker:

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -37,7 +37,7 @@ from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import ApitallySpanProcessor, get_server_span_processor
 from apitally.shared.spool import SEND_HORIZON, Spool
-from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, unwrap
+from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, installed, unwrap
 
 
 @pytest.fixture(autouse=True)
@@ -333,3 +333,134 @@ def test_shutdown_performs_final_drain_and_stops_thread(
     assert unwrap(worker.thread).is_alive() is False
     assert otlp_server.paths() == ["/v1/traces"]
     assert spool.pending_files() == []
+
+
+starlette_required = pytest.mark.skipif(
+    not installed("starlette", "opentelemetry.instrumentation.starlette"),
+    reason="end-to-end tests use the Starlette adapter",
+)
+
+
+def create_starlette_client(otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch, **kwargs: Any) -> Any:
+    from starlette.applications import Starlette
+    from starlette.requests import Request
+    from starlette.responses import JSONResponse
+    from starlette.routing import Route
+    from starlette.testclient import TestClient
+
+    from apitally.starlette import init_apitally
+
+    async def get_item(request: Request) -> JSONResponse:
+        logging.getLogger("myapp").warning("handling item")
+        return JSONResponse({"item_id": request.path_params["item_id"]})
+
+    async def login(request: Request) -> JSONResponse:
+        await request.json()
+        return JSONResponse({"ok": True})
+
+    app = Starlette(routes=[Route("/items/{item_id}", get_item), Route("/login", login, methods=["POST"])])
+    monkeypatch.setenv("APITALLY_OTLP_ENDPOINT", otlp_server.url)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 60.0)
+    init_apitally(app, write_token=WRITE_TOKEN, **kwargs)
+    return TestClient(app)
+
+
+def decoded_records(otlp_server: StubOTLPServer, path: str, message_type: Any) -> list[Any]:
+    return [
+        message_type.FromString(gzip.decompress(body))
+        for request_path, _, body in otlp_server.requests
+        if request_path == path
+    ]
+
+
+@starlette_required
+def test_end_to_end_request_delivers_all_three_signals_decoded(
+    otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
+
+    from apitally.shared import activation, startup
+
+    with create_starlette_client(otlp_server, monkeypatch) as client:
+        assert client.get("/items/42").status_code == 200
+        assert unwrap(activation.spool).in_memory is False
+        unwrap(activation.export_worker).run_cycle(None)
+
+    assert {"/v1/traces", "/v1/logs", "/v1/metrics"} <= set(otlp_server.paths())
+
+    (trace_request,) = decoded_records(otlp_server, "/v1/traces", ExportTraceServiceRequest)
+    (server_span,) = [
+        span
+        for rs in trace_request.resource_spans
+        for ss in rs.scope_spans
+        for span in ss.spans
+        if not span.parent_span_id
+    ]
+    attributes = {kv.key: kv.value for kv in server_span.attributes}
+    assert attributes["http.route"].string_value == "/items/{item_id}"
+    assert attributes["http.response.status_code"].int_value == 200
+
+    (log_request,) = decoded_records(otlp_server, "/v1/logs", ExportLogsServiceRequest)
+    records = [record for rl in log_request.resource_logs for sl in rl.scope_logs for record in sl.log_records]
+    assert any(record.event_name == startup.EVENT_NAME for record in records)
+    assert any(record.body.string_value == "handling item" for record in records)
+
+    (metrics_request,) = decoded_records(otlp_server, "/v1/metrics", ExportMetricsServiceRequest)
+    metric_names = {
+        metric.name for rm in metrics_request.resource_metrics for sm in rm.scope_metrics for metric in sm.metrics
+    }
+    assert "http.server.request.duration" in metric_names
+
+
+@starlette_required
+def test_end_to_end_sensitive_body_redacted_on_disk_and_wire(
+    otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from apitally.shared import activation
+
+    with create_starlette_client(otlp_server, monkeypatch, log_request_body=True) as client:
+        assert client.post("/login", json={"password": "hunter2"}).status_code == 200
+        spool = unwrap(activation.spool)
+        unwrap(activation.span_processor).downstream.force_flush()
+        spool.close_current_files()
+        disk_payloads = b"".join(
+            gzip.decompress(file.read_bytes()) for file in spool.pending_files() if file.signal == "traces"
+        )
+        assert b"hunter2" not in disk_payloads
+        assert b"apitally.request.body" in disk_payloads
+        assert REDACTED.encode() in disk_payloads
+        unwrap(activation.export_worker).run_cycle(None)
+
+    wire_payloads = b"".join(gzip.decompress(body) for _, _, body in otlp_server.requests)
+    assert b"hunter2" not in wire_payloads
+    assert b"apitally.request.body" in wire_payloads
+    assert REDACTED.encode() in wire_payloads
+
+
+@starlette_required
+def test_end_to_end_downtime_data_delivered_byte_identical_after_recovery(
+    otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from apitally.shared import activation
+
+    otlp_server.respond = lambda path: (503, {})
+    with create_starlette_client(otlp_server, monkeypatch) as client:
+        assert client.get("/items/42").status_code == 200
+        worker = unwrap(activation.export_worker)
+        worker.run_cycle(None)
+        assert unwrap(activation.spool).pending_files()
+        first_attempt_bodies = {path: body for path, _, body in otlp_server.requests}
+
+        otlp_server.respond = lambda path: (200, {})
+        worker.run_cycle(None)
+        worker.run_cycle(None)
+        assert unwrap(activation.spool).pending_files() == []
+
+    for path, body in first_attempt_bodies.items():
+        delivered = [b for p, _, b in otlp_server.requests[len(first_attempt_bodies) :] if p == path]
+        assert body in delivered
+
+    trace_request = decoded_records(otlp_server, "/v1/traces", ExportTraceServiceRequest)[-1]
+    span_names = [span.name for rs in trace_request.resource_spans for ss in rs.scope_spans for span in ss.spans]
+    assert any("/items" in name for name in span_names)

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -1,0 +1,145 @@
+import gzip
+import logging
+from collections.abc import Iterator
+
+import pytest
+from opentelemetry.instrumentation.logging.handler import LoggingHandler
+from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.logs.v1.logs_pb2 import LogRecord as PB2LogRecord
+from opentelemetry.sdk._logs import LoggerProvider
+from opentelemetry.sdk._logs.export import SimpleLogRecordProcessor
+from opentelemetry.sdk.resources import Resource
+from opentelemetry.sdk.trace import TracerProvider
+from opentelemetry.sdk.trace.export import SimpleSpanProcessor
+from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
+from opentelemetry.sdk.trace.sampling import ALWAYS_ON
+from opentelemetry.trace import SpanKind
+
+from apitally.shared.config import set_config
+from apitally.shared.export import ENCODE_CHUNK_SIZE, MAX_LOG_VALUE_LENGTH, SpoolLogExporter, SpoolSpanExporter
+from apitally.shared.exporter import ApitallySpanExporter
+from apitally.shared.redaction import REDACTED
+from apitally.shared.span_processor import ApitallySpanProcessor, get_server_span_processor
+from apitally.shared.spool import Spool
+from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, unwrap
+
+
+@pytest.fixture
+def spool() -> Iterator[Spool]:
+    spool = Spool()
+    yield spool
+    spool.clear()
+
+
+def read_trace_request(spool: Spool) -> ExportTraceServiceRequest:
+    spool.rotate_for_export()
+    (file,) = [file for file in spool.pending_files() if file.signal == "traces"]
+    return ExportTraceServiceRequest.FromString(gzip.decompress(file.read_bytes()))
+
+
+def read_log_request(spool: Spool) -> ExportLogsServiceRequest:
+    spool.rotate_for_export()
+    (file,) = [file for file in spool.pending_files() if file.signal == "logs"]
+    return ExportLogsServiceRequest.FromString(gzip.decompress(file.read_bytes()))
+
+
+def read_log_records(spool: Spool) -> list[PB2LogRecord]:
+    request = read_log_request(spool)
+    return [record for rl in request.resource_logs for sl in rl.scope_logs for record in sl.log_records]
+
+
+def make_log_provider(spool: Spool) -> LoggerProvider:
+    provider = LoggerProvider(resource=Resource.create({}))
+    provider.add_log_record_processor(SimpleLogRecordProcessor(SpoolLogExporter(spool)))
+    return provider
+
+
+def emit_log(spool: Spool, msg: str) -> None:
+    handler = LoggingHandler(level=logging.NOTSET, logger_provider=make_log_provider(spool), log_code_attributes=True)
+    handler.emit(
+        logging.LogRecord(
+            name="app", level=logging.INFO, pathname=__file__, lineno=1, msg=msg, args=None, exc_info=None
+        )
+    )
+
+
+def test_span_batch_lands_in_spool_as_parseable_payload(spool: Spool) -> None:
+    provider = TracerProvider(sampler=ALWAYS_ON)
+    provider.add_span_processor(SimpleSpanProcessor(ApitallySpanExporter(SpoolSpanExporter(spool))))
+    with provider.get_tracer(CONTRIB_SCOPE).start_as_current_span("GET /items", kind=SpanKind.SERVER):
+        pass
+    request = read_trace_request(spool)
+    (resource_spans,) = request.resource_spans
+    assert [span.name for ss in resource_spans.scope_spans for span in ss.spans] == ["GET /items"]
+    assert "service.name" in {kv.key for kv in resource_spans.resource.attributes}
+
+
+def test_stashed_body_and_headers_reach_spool_redacted(spool: Spool) -> None:
+    set_config(write_token=WRITE_TOKEN, log_request_headers=True, log_request_body=True)
+    provider = TracerProvider(sampler=ALWAYS_ON)
+    provider.add_span_processor(
+        ApitallySpanProcessor(SimpleSpanProcessor(ApitallySpanExporter(SpoolSpanExporter(spool))))
+    )
+    tracer = provider.get_tracer(CONTRIB_SCOPE)
+    with tracer.start_as_current_span("POST /login", kind=SpanKind.SERVER) as span:
+        processor = unwrap(get_server_span_processor())
+        processor.update_stash(
+            span.get_span_context().span_id,
+            request_headers={"authorization": ["Bearer secret123"], "accept": ["application/json"]},
+            request_body=b'{"password": "hunter2"}',
+        )
+    spool.rotate_for_export()
+    (file,) = spool.pending_files()
+    payload = gzip.decompress(file.read_bytes())
+    assert b"secret123" not in payload
+    assert b"hunter2" not in payload
+    assert REDACTED.encode() in payload
+    assert b"application/json" in payload
+
+
+def test_log_batch_lands_in_spool_as_parseable_payload(spool: Spool) -> None:
+    emit_log(spool, "something happened")
+    (record,) = read_log_records(spool)
+    assert record.body.string_value == "something happened"
+
+
+def test_large_batch_appends_multiple_payloads_without_loss(spool: Spool) -> None:
+    provider = TracerProvider(sampler=ALWAYS_ON)
+    memory_exporter = InMemorySpanExporter()
+    provider.add_span_processor(SimpleSpanProcessor(memory_exporter))
+    tracer = provider.get_tracer(CONTRIB_SCOPE)
+    span_names = [f"span-{i}" for i in range(ENCODE_CHUNK_SIZE + 8)]
+    for name in span_names:
+        with tracer.start_as_current_span(name):
+            pass
+    SpoolSpanExporter(spool).export(memory_exporter.get_finished_spans())
+    request = read_trace_request(spool)
+    assert len(request.resource_spans) == 2
+    exported_names = [span.name for rs in request.resource_spans for ss in rs.scope_spans for span in ss.spans]
+    assert sorted(exported_names) == sorted(span_names)
+
+
+def test_oversized_log_body_is_truncated_at_encode_time(spool: Spool) -> None:
+    emit_log(spool, "x" * (MAX_LOG_VALUE_LENGTH + 1000))
+    (record,) = read_log_records(spool)
+    assert record.body.string_value == "x" * MAX_LOG_VALUE_LENGTH
+    assert record.severity_text == "INFO"
+    assert any(kv.key == "code.file.path" for kv in record.attributes)
+
+
+def test_oversized_log_attribute_value_is_truncated_at_encode_time(spool: Spool) -> None:
+    provider = make_log_provider(spool)
+    provider.get_logger("app").emit(body="hello", attributes={"detail": "y" * (MAX_LOG_VALUE_LENGTH + 1000)})
+    (record,) = read_log_records(spool)
+    attributes = {kv.key: kv.value.string_value for kv in record.attributes}
+    assert attributes["detail"] == "y" * MAX_LOG_VALUE_LENGTH
+    assert record.body.string_value == "hello"
+
+
+def test_apitally_scope_records_are_exempt_from_truncation(spool: Spool) -> None:
+    provider = make_log_provider(spool)
+    long_body = "{" + "a" * (MAX_LOG_VALUE_LENGTH * 2) + "}"
+    provider.get_logger("apitally").emit(body=long_body, event_name="apitally.startup")
+    (record,) = read_log_records(spool)
+    assert record.body.string_value == long_body

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -41,7 +41,7 @@ from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import ApitallySpanProcessor, get_server_span_processor
 from apitally.shared.spool import MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT, MAX_UNCOMPRESSED_FILE_SIZE, Spool
-from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, installed, read_spool_file, unwrap
+from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, installed, read_spool_payload, unwrap
 
 
 @pytest.fixture
@@ -60,13 +60,13 @@ def make_worker(spool: Spool, endpoint: str) -> ExportWorker:
 def read_trace_request(spool: Spool) -> ExportTraceServiceRequest:
     spool.rotate_for_export()
     (file,) = [file for file in spool.pending_files() if file.signal == "traces"]
-    return ExportTraceServiceRequest.FromString(gzip.decompress(read_spool_file(file)))
+    return ExportTraceServiceRequest.FromString(read_spool_payload(file))
 
 
 def read_log_request(spool: Spool) -> ExportLogsServiceRequest:
     spool.rotate_for_export()
     (file,) = [file for file in spool.pending_files() if file.signal == "logs"]
-    return ExportLogsServiceRequest.FromString(gzip.decompress(read_spool_file(file)))
+    return ExportLogsServiceRequest.FromString(read_spool_payload(file))
 
 
 def read_log_records(spool: Spool) -> list[PB2LogRecord]:
@@ -116,7 +116,7 @@ def test_stashed_body_and_headers_reach_spool_redacted(spool: Spool) -> None:
         )
     spool.rotate_for_export()
     (file,) = spool.pending_files()
-    payload = gzip.decompress(read_spool_file(file))
+    payload = read_spool_payload(file)
     assert b"secret123" not in payload
     assert b"hunter2" not in payload
     assert REDACTED.encode() in payload
@@ -475,9 +475,7 @@ def test_end_to_end_sensitive_body_redacted_on_disk_and_wire(
         spool = unwrap(activation.spool)
         unwrap(activation.span_processor).downstream.force_flush()
         spool.close_current_files()
-        disk_payloads = b"".join(
-            gzip.decompress(read_spool_file(file)) for file in spool.pending_files() if file.signal == "traces"
-        )
+        disk_payloads = b"".join(read_spool_payload(file) for file in spool.pending_files() if file.signal == "traces")
         assert b"hunter2" not in disk_payloads
         assert b"apitally.request.body" in disk_payloads
         assert REDACTED.encode() in disk_payloads

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -11,6 +11,7 @@ import pytest
 from opentelemetry.instrumentation.logging.handler import LoggingHandler
 from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 from opentelemetry.proto.logs.v1.logs_pb2 import LogRecord as PB2LogRecord
 from opentelemetry.sdk._logs import LoggerProvider
@@ -22,7 +23,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.trace import SpanKind
 
-from apitally.shared import export, metrics
+from apitally.shared import activation, export, metrics, startup
 from apitally.shared import spool as spool_module
 from apitally.shared.config import set_config
 from apitally.shared.export import (
@@ -239,7 +240,7 @@ def test_expired_attempted_file_evicted_while_never_attempted_file_delivers(
     spool.append("logs", b"never-attempted")
     spool.rotate_for_export()
     files = {file.signal: file for file in spool.pending_files()}
-    files["traces"].first_attempt_at = time.time() - SEND_HORIZON - 1
+    files["traces"].first_attempt_at = time.monotonic() - SEND_HORIZON - 1
     files["logs"].created_at = time.time() - 2 * SEND_HORIZON
     with caplog.at_level(logging.WARNING):
         worker.run_cycle(None)
@@ -253,7 +254,7 @@ def test_send_site_evicts_file_past_horizon_instead_of_sending(spool: Spool, otl
     spool.append("traces", b"trace-payload")
     spool.rotate_for_export()
     (file,) = spool.pending_files()
-    file.first_attempt_at = time.time() - SEND_HORIZON - 1
+    file.first_attempt_at = time.monotonic() - SEND_HORIZON - 1
     worker.send_pending(None)
     assert otlp_server.requests == []
     assert spool.pending_files() == []
@@ -335,6 +336,49 @@ def test_shutdown_performs_final_drain_and_stops_thread(
     assert spool.pending_files() == []
 
 
+def test_unreadable_file_is_dropped_without_blocking_the_queue(
+    spool: Spool, otlp_server: StubOTLPServer, caplog: pytest.LogCaptureFixture
+) -> None:
+    worker = make_worker(spool, otlp_server.url)
+    spool.append("traces", b"trace-payload")
+    spool.rotate_for_export()
+    spool.append("logs", b"log-payload")
+    files = {file.signal: file for file in spool.pending_files()}
+    files["traces"].sink.close()
+    with caplog.at_level(logging.WARNING, logger="apitally.shared.export"):
+        worker.run_cycle(None)
+    assert otlp_server.paths() == ["/v1/logs"]
+    assert spool.pending_files() == []
+    assert any("traces" in record.getMessage() for record in caplog.records)
+
+
+def test_start_after_timed_out_stop_replaces_stuck_thread(
+    spool: Spool, otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    def slow_ok(path: str) -> tuple[int, dict[str, str]]:
+        time.sleep(1.0)
+        return (200, {})
+
+    otlp_server.respond = slow_ok
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 0.01)
+    worker = make_worker(spool, otlp_server.url)
+    spool.append("traces", b"trace-payload")
+    worker.start()
+    deadline = time.time() + 5
+    while not otlp_server.requests and time.time() < deadline:
+        time.sleep(0.005)
+    worker.stop(timeout=0.05)
+    stuck_thread = unwrap(worker.thread)
+    assert stuck_thread.is_alive()
+    worker.start()
+    new_thread = unwrap(worker.thread)
+    assert new_thread is not stuck_thread
+    assert new_thread.is_alive()
+    worker.stop()
+    stuck_thread.join(5)
+    assert not stuck_thread.is_alive()
+
+
 starlette_required = pytest.mark.skipif(
     not installed("starlette", "opentelemetry.instrumentation.starlette"),
     reason="end-to-end tests use the Starlette adapter",
@@ -378,10 +422,6 @@ def decoded_records(otlp_server: StubOTLPServer, path: str, message_type: Any) -
 def test_end_to_end_request_delivers_all_three_signals_decoded(
     otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
-
-    from apitally.shared import activation, startup
-
     with create_starlette_client(otlp_server, monkeypatch) as client:
         assert client.get("/items/42").status_code == 200
         assert unwrap(activation.spool).in_memory is False
@@ -417,8 +457,6 @@ def test_end_to_end_request_delivers_all_three_signals_decoded(
 def test_end_to_end_sensitive_body_redacted_on_disk_and_wire(
     otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from apitally.shared import activation
-
     with create_starlette_client(otlp_server, monkeypatch, log_request_body=True) as client:
         assert client.post("/login", json={"password": "hunter2"}).status_code == 200
         spool = unwrap(activation.spool)
@@ -442,8 +480,6 @@ def test_end_to_end_sensitive_body_redacted_on_disk_and_wire(
 def test_end_to_end_downtime_data_delivered_byte_identical_after_recovery(
     otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    from apitally.shared import activation
-
     otlp_server.respond = lambda path: (503, {})
     with create_starlette_client(otlp_server, monkeypatch) as client:
         assert client.get("/items/42").status_code == 200

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -24,12 +24,13 @@ from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.trace import SpanKind
 
 from apitally.shared import activation, export, metrics, startup
-from apitally.shared import spool as spool_module
 from apitally.shared.config import set_config
 from apitally.shared.export import (
     ENCODE_CHUNK_SIZE,
     EXPORT_INTERVAL_HEADER,
+    MAX_EXPORT_INTERVAL,
     MAX_LOG_VALUE_LENGTH,
+    MIN_EXPORT_INTERVAL,
     ExportWorker,
     SpoolLogExporter,
     SpoolSpanExporter,
@@ -37,14 +38,8 @@ from apitally.shared.export import (
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import ApitallySpanProcessor, get_server_span_processor
-from apitally.shared.spool import SEND_HORIZON, Spool
-from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, installed, unwrap
-
-
-@pytest.fixture(autouse=True)
-def reset_duplicate_log_filter() -> Iterator[None]:
-    spool_module.duplicate_log_filter.last_logged.clear()
-    yield
+from apitally.shared.spool import MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT, Spool
+from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, installed, read_spool_file, unwrap
 
 
 @pytest.fixture
@@ -63,13 +58,13 @@ def make_worker(spool: Spool, endpoint: str) -> ExportWorker:
 def read_trace_request(spool: Spool) -> ExportTraceServiceRequest:
     spool.rotate_for_export()
     (file,) = [file for file in spool.pending_files() if file.signal == "traces"]
-    return ExportTraceServiceRequest.FromString(gzip.decompress(file.read_bytes()))
+    return ExportTraceServiceRequest.FromString(gzip.decompress(read_spool_file(file)))
 
 
 def read_log_request(spool: Spool) -> ExportLogsServiceRequest:
     spool.rotate_for_export()
     (file,) = [file for file in spool.pending_files() if file.signal == "logs"]
-    return ExportLogsServiceRequest.FromString(gzip.decompress(file.read_bytes()))
+    return ExportLogsServiceRequest.FromString(gzip.decompress(read_spool_file(file)))
 
 
 def read_log_records(spool: Spool) -> list[PB2LogRecord]:
@@ -92,7 +87,7 @@ def emit_log(spool: Spool, msg: str) -> None:
     )
 
 
-def test_span_batch_lands_in_spool_as_parseable_payload(spool: Spool) -> None:
+def test_span_batch_is_written_to_spool_as_parseable_payload(spool: Spool) -> None:
     provider = TracerProvider(sampler=ALWAYS_ON)
     provider.add_span_processor(SimpleSpanProcessor(ApitallySpanExporter(SpoolSpanExporter(spool))))
     with provider.get_tracer(CONTRIB_SCOPE).start_as_current_span("GET /items", kind=SpanKind.SERVER):
@@ -119,14 +114,14 @@ def test_stashed_body_and_headers_reach_spool_redacted(spool: Spool) -> None:
         )
     spool.rotate_for_export()
     (file,) = spool.pending_files()
-    payload = gzip.decompress(file.read_bytes())
+    payload = gzip.decompress(read_spool_file(file))
     assert b"secret123" not in payload
     assert b"hunter2" not in payload
     assert REDACTED.encode() in payload
     assert b"application/json" in payload
 
 
-def test_log_batch_lands_in_spool_as_parseable_payload(spool: Spool) -> None:
+def test_log_batch_is_written_to_spool_as_parseable_payload(spool: Spool) -> None:
     emit_log(spool, "something happened")
     (record,) = read_log_records(spool)
     assert record.body.string_value == "something happened"
@@ -148,7 +143,7 @@ def test_large_batch_appends_multiple_payloads_without_loss(spool: Spool) -> Non
     assert sorted(exported_names) == sorted(span_names)
 
 
-def test_oversized_log_body_is_truncated_at_encode_time(spool: Spool) -> None:
+def test_oversized_log_body_is_truncated(spool: Spool) -> None:
     emit_log(spool, "x" * (MAX_LOG_VALUE_LENGTH + 1000))
     (record,) = read_log_records(spool)
     assert record.body.string_value == "x" * MAX_LOG_VALUE_LENGTH
@@ -156,7 +151,7 @@ def test_oversized_log_body_is_truncated_at_encode_time(spool: Spool) -> None:
     assert any(kv.key == "code.file.path" for kv in record.attributes)
 
 
-def test_oversized_log_attribute_value_is_truncated_at_encode_time(spool: Spool) -> None:
+def test_oversized_log_attribute_value_is_truncated(spool: Spool) -> None:
     provider = make_log_provider(spool)
     provider.get_logger("app").emit(body="hello", attributes={"detail": "y" * (MAX_LOG_VALUE_LENGTH + 1000)})
     (record,) = read_log_records(spool)
@@ -232,7 +227,7 @@ def test_outage_sends_one_probe_per_cycle_without_accumulating_files(spool: Spoo
     assert otlp_server.paths() == ["/v1/traces"] * 3
 
 
-def test_expired_attempted_file_evicted_while_never_attempted_file_delivers(
+def test_expired_file_dropped_before_sending_while_never_attempted_file_delivers(
     spool: Spool, otlp_server: StubOTLPServer, caplog: pytest.LogCaptureFixture
 ) -> None:
     worker = make_worker(spool, otlp_server.url)
@@ -240,23 +235,12 @@ def test_expired_attempted_file_evicted_while_never_attempted_file_delivers(
     spool.append("logs", b"never-attempted")
     spool.rotate_for_export()
     files = {file.signal: file for file in spool.pending_files()}
-    files["traces"].first_attempt_at = time.monotonic() - SEND_HORIZON - 1
+    files["traces"].first_attempt_at = time.monotonic() - MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT - 1
     with caplog.at_level(logging.WARNING):
-        worker.run_cycle(None)
+        worker.send_pending(None)
     assert otlp_server.paths() == ["/v1/logs"]
     assert spool.pending_files() == []
     assert any("could not be delivered" in record.message for record in caplog.records)
-
-
-def test_send_site_evicts_file_past_horizon_instead_of_sending(spool: Spool, otlp_server: StubOTLPServer) -> None:
-    worker = make_worker(spool, otlp_server.url)
-    spool.append("traces", b"trace-payload")
-    spool.rotate_for_export()
-    (file,) = spool.pending_files()
-    file.first_attempt_at = time.monotonic() - SEND_HORIZON - 1
-    worker.send_pending(None)
-    assert otlp_server.requests == []
-    assert spool.pending_files() == []
 
 
 def test_permanent_failure_drops_only_that_file_and_warns_once(
@@ -280,7 +264,12 @@ def test_interval_header_applies_with_clamping(spool: Spool, otlp_server: StubOT
     header_value = {"value": "5"}
     otlp_server.respond = lambda path: (200, {EXPORT_INTERVAL_HEADER: header_value["value"]})
     worker = make_worker(spool, otlp_server.url)
-    for value, expected_interval in (("5", 5.0), ("10000", 900.0), ("1", 5.0), ("not-a-number", 5.0)):
+    for value, expected_interval in (
+        ("5", 5.0),
+        ("10000", float(MAX_EXPORT_INTERVAL)),
+        ("1", float(MIN_EXPORT_INTERVAL)),
+        ("not-a-number", float(MIN_EXPORT_INTERVAL)),
+    ):
         header_value["value"] = value
         spool.append("traces", b"trace-payload")
         worker.run_cycle(None)
@@ -462,7 +451,7 @@ def test_end_to_end_sensitive_body_redacted_on_disk_and_wire(
         unwrap(activation.span_processor).downstream.force_flush()
         spool.close_current_files()
         disk_payloads = b"".join(
-            gzip.decompress(file.read_bytes()) for file in spool.pending_files() if file.signal == "traces"
+            gzip.decompress(read_spool_file(file)) for file in spool.pending_files() if file.signal == "traces"
         )
         assert b"hunter2" not in disk_payloads
         assert b"apitally.request.body" in disk_payloads

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -1,6 +1,7 @@
 import gzip
 import logging
 import socket
+import threading
 import time
 from collections import deque
 from collections.abc import Iterator
@@ -30,6 +31,7 @@ from apitally.shared.export import (
     EXPORT_INTERVAL_HEADER,
     MAX_EXPORT_INTERVAL,
     MAX_LOG_VALUE_LENGTH,
+    MAX_SENDS_PER_CYCLE,
     MIN_EXPORT_INTERVAL,
     ExportWorker,
     SpoolLogExporter,
@@ -38,7 +40,7 @@ from apitally.shared.export import (
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import ApitallySpanProcessor, get_server_span_processor
-from apitally.shared.spool import MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT, Spool
+from apitally.shared.spool import MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT, MAX_UNCOMPRESSED_FILE_SIZE, Spool
 from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, installed, read_spool_file, unwrap
 
 
@@ -225,6 +227,29 @@ def test_outage_sends_one_probe_per_cycle_without_accumulating_files(spool: Spoo
         worker.run_cycle(None)
     assert len(spool.pending_files()) == 1
     assert otlp_server.paths() == ["/v1/traces"] * 3
+
+
+def test_sends_per_cycle_are_capped(spool: Spool, otlp_server: StubOTLPServer) -> None:
+    worker = make_worker(spool, otlp_server.url)
+    for _ in range(MAX_SENDS_PER_CYCLE + 2):
+        spool.append("traces", b"x" * MAX_UNCOMPRESSED_FILE_SIZE)
+    worker.send_pending(None)
+    assert len(otlp_server.paths()) == MAX_SENDS_PER_CYCLE
+    assert len(spool.pending_files()) == 1
+
+
+def test_stop_during_pacing_wait_ends_drain(
+    spool: Spool, otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    worker = make_worker(spool, otlp_server.url)
+    spool.append("traces", b"trace-payload")
+    spool.append("logs", b"log-payload")
+    spool.rotate_for_export()
+    stop_event = threading.Event()
+    monkeypatch.setattr(stop_event, "wait", lambda timeout=None: True)
+    worker.send_pending(stop_event)
+    assert len(otlp_server.paths()) == 1
+    assert len(spool.pending_files()) == 1
 
 
 def test_expired_file_dropped_before_sending_while_never_attempted_file_delivers(

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -241,7 +241,6 @@ def test_expired_attempted_file_evicted_while_never_attempted_file_delivers(
     spool.rotate_for_export()
     files = {file.signal: file for file in spool.pending_files()}
     files["traces"].first_attempt_at = time.monotonic() - SEND_HORIZON - 1
-    files["logs"].created_at = time.time() - 2 * SEND_HORIZON
     with caplog.at_level(logging.WARNING):
         worker.run_cycle(None)
     assert otlp_server.paths() == ["/v1/logs"]

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -1,9 +1,17 @@
 import gzip
 import logging
-from collections.abc import Iterator
+import socket
+import threading
+import time
+from collections import deque
+from collections.abc import Callable, Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from opentelemetry.instrumentation.logging.handler import LoggingHandler
+from opentelemetry.instrumentation.utils import is_instrumentation_enabled
 from opentelemetry.proto.collector.logs.v1.logs_service_pb2 import ExportLogsServiceRequest
 from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
 from opentelemetry.proto.logs.v1.logs_pb2 import LogRecord as PB2LogRecord
@@ -16,13 +24,28 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.trace import SpanKind
 
+from apitally.shared import export, metrics
+from apitally.shared import spool as spool_module
 from apitally.shared.config import set_config
-from apitally.shared.export import ENCODE_CHUNK_SIZE, MAX_LOG_VALUE_LENGTH, SpoolLogExporter, SpoolSpanExporter
+from apitally.shared.export import (
+    ENCODE_CHUNK_SIZE,
+    EXPORT_INTERVAL_HEADER,
+    MAX_LOG_VALUE_LENGTH,
+    ExportWorker,
+    SpoolLogExporter,
+    SpoolSpanExporter,
+)
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.redaction import REDACTED
 from apitally.shared.span_processor import ApitallySpanProcessor, get_server_span_processor
-from apitally.shared.spool import Spool
+from apitally.shared.spool import SEND_HORIZON, Spool
 from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, unwrap
+
+
+@pytest.fixture(autouse=True)
+def reset_duplicate_log_filter() -> Iterator[None]:
+    spool_module.duplicate_log_filter.last_logged.clear()
+    yield
 
 
 @pytest.fixture
@@ -30,6 +53,54 @@ def spool() -> Iterator[Spool]:
     spool = Spool()
     yield spool
     spool.clear()
+
+
+class StubOTLPServer:
+    """Local HTTP server recording POSTed requests, with scriptable responses per path."""
+
+    def __init__(self) -> None:
+        self.requests: list[tuple[str, dict[str, str], bytes]] = []
+        self.respond: Callable[[str], tuple[int, dict[str, str]]] = lambda path: (200, {})
+        stub = self
+
+        class Handler(BaseHTTPRequestHandler):
+            def do_POST(self) -> None:
+                body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
+                stub.requests.append((self.path, dict(self.headers), body))
+                status, headers = stub.respond(self.path)
+                self.send_response(status)
+                for key, value in headers.items():
+                    self.send_header(key, value)
+                self.send_header("Content-Length", "0")
+                self.end_headers()
+
+            def log_message(self, format: str, *args: Any) -> None:
+                pass
+
+        self.server = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+        self.thread = threading.Thread(target=self.server.serve_forever, daemon=True)
+        self.thread.start()
+
+    @property
+    def url(self) -> str:
+        return f"http://127.0.0.1:{self.server.server_address[1]}"
+
+    def paths(self) -> list[str]:
+        return [path for path, _, _ in self.requests]
+
+
+@pytest.fixture
+def otlp_server() -> Iterator[StubOTLPServer]:
+    stub = StubOTLPServer()
+    yield stub
+    stub.server.shutdown()
+    stub.server.server_close()
+
+
+def make_worker(spool: Spool, endpoint: str) -> ExportWorker:
+    set_config(write_token=WRITE_TOKEN, env="dev", otlp_endpoint=endpoint)
+    processor_stub = SimpleNamespace(downstream=SimpleNamespace(force_flush=lambda timeout_millis=30_000: True))
+    return ExportWorker(spool, cast("Any", processor_stub), cast("Any", processor_stub), env="dev")
 
 
 def read_trace_request(spool: Spool) -> ExportTraceServiceRequest:
@@ -143,3 +214,166 @@ def test_apitally_scope_records_are_exempt_from_truncation(spool: Spool) -> None
     provider.get_logger("apitally").emit(body=long_body, event_name="apitally.startup")
     (record,) = read_log_records(spool)
     assert record.body.string_value == long_body
+
+
+def test_export_cycle_posts_all_three_signals_in_lockstep(spool: Spool, otlp_server: StubOTLPServer) -> None:
+    worker = make_worker(spool, otlp_server.url)
+    metrics.setup(Resource.create({}))
+    metrics.attach_reader(spool)
+    metrics.record_request("GET", "/a", 200, consumer=None, duration=0.1)
+    spool.append("traces", b"trace-payload")
+    spool.append("logs", b"log-payload")
+    worker.run_cycle(None)
+    assert sorted(otlp_server.paths()) == ["/v1/logs", "/v1/metrics", "/v1/traces"]
+    _, headers, body = next(request for request in otlp_server.requests if request[0] == "/v1/traces")
+    assert headers["Authorization"] == f"Bearer {WRITE_TOKEN}"
+    assert headers["Apitally-Env"] == "dev"
+    assert headers["Content-Type"] == "application/x-protobuf"
+    assert headers["Content-Encoding"] == "gzip"
+    assert headers["User-Agent"].startswith("apitally-py/")
+    assert gzip.decompress(body) == b"trace-payload"
+    assert spool.pending_files() == []
+
+
+def test_failed_send_retries_next_cycle_with_identical_bytes(spool: Spool, otlp_server: StubOTLPServer) -> None:
+    failures = deque([503])
+    otlp_server.respond = lambda path: (failures.popleft() if failures else 200, {})
+    worker = make_worker(spool, otlp_server.url)
+    spool.append("traces", b"trace-payload")
+    worker.run_cycle(None)
+    assert len(spool.pending_files()) == 1
+    worker.run_cycle(None)
+    assert spool.pending_files() == []
+    first_body, second_body = [body for _, _, body in otlp_server.requests]
+    assert first_body == second_body
+    assert gzip.decompress(first_body) == b"trace-payload"
+
+
+def test_connection_error_keeps_files_and_ends_cycle(spool: Spool) -> None:
+    sock = socket.socket()
+    sock.bind(("127.0.0.1", 0))
+    unused_port = sock.getsockname()[1]
+    sock.close()
+    worker = make_worker(spool, f"http://127.0.0.1:{unused_port}")
+    spool.append("traces", b"trace-payload")
+    spool.rotate_for_export()
+    spool.append("logs", b"log-payload")
+    worker.run_cycle(None)
+    files = {file.signal: file for file in spool.pending_files()}
+    assert set(files) == {"traces", "logs"}
+    assert files["traces"].first_attempt_at is not None
+    assert files["logs"].first_attempt_at is None
+
+
+def test_outage_sends_one_probe_per_cycle_without_accumulating_files(spool: Spool, otlp_server: StubOTLPServer) -> None:
+    otlp_server.respond = lambda path: (503, {})
+    worker = make_worker(spool, otlp_server.url)
+    for _ in range(3):
+        spool.append("traces", b"recorded-during-outage")
+        worker.run_cycle(None)
+    assert len(spool.pending_files()) == 1
+    assert otlp_server.paths() == ["/v1/traces"] * 3
+
+
+def test_expired_attempted_file_evicted_while_never_attempted_file_delivers(
+    spool: Spool, otlp_server: StubOTLPServer, caplog: pytest.LogCaptureFixture
+) -> None:
+    worker = make_worker(spool, otlp_server.url)
+    spool.append("traces", b"attempted-once")
+    spool.append("logs", b"never-attempted")
+    spool.rotate_for_export()
+    files = {file.signal: file for file in spool.pending_files()}
+    files["traces"].first_attempt_at = time.time() - SEND_HORIZON - 1
+    files["logs"].created_at = time.time() - 2 * SEND_HORIZON
+    with caplog.at_level(logging.WARNING):
+        worker.run_cycle(None)
+    assert otlp_server.paths() == ["/v1/logs"]
+    assert spool.pending_files() == []
+    assert any("could not be delivered" in record.message for record in caplog.records)
+
+
+def test_send_site_evicts_file_past_horizon_instead_of_sending(spool: Spool, otlp_server: StubOTLPServer) -> None:
+    worker = make_worker(spool, otlp_server.url)
+    spool.append("traces", b"trace-payload")
+    spool.rotate_for_export()
+    (file,) = spool.pending_files()
+    file.first_attempt_at = time.time() - SEND_HORIZON - 1
+    worker.send_pending(None)
+    assert otlp_server.requests == []
+    assert spool.pending_files() == []
+
+
+def test_permanent_failure_drops_only_that_file_and_warns_once(
+    spool: Spool, otlp_server: StubOTLPServer, caplog: pytest.LogCaptureFixture
+) -> None:
+    otlp_server.respond = lambda path: (402, {}) if path == "/v1/traces" else (200, {})
+    worker = make_worker(spool, otlp_server.url)
+    spool.append("traces", b"trace-payload")
+    spool.append("logs", b"log-payload")
+    with caplog.at_level(logging.WARNING):
+        worker.run_cycle(None)
+        assert spool.pending_files() == []
+        assert otlp_server.paths() == ["/v1/traces", "/v1/logs"]
+        spool.append("traces", b"more-trace-payload")
+        worker.run_cycle(None)
+    assert spool.pending_files() == []
+    assert len([record for record in caplog.records if "rejected" in record.message]) == 1
+
+
+def test_interval_header_applies_with_clamping(spool: Spool, otlp_server: StubOTLPServer) -> None:
+    header_value = {"value": "5"}
+    otlp_server.respond = lambda path: (200, {EXPORT_INTERVAL_HEADER: header_value["value"]})
+    worker = make_worker(spool, otlp_server.url)
+    for value, expected_interval in (("5", 5.0), ("10000", 900.0), ("1", 5.0), ("not-a-number", 5.0)):
+        header_value["value"] = value
+        spool.append("traces", b"trace-payload")
+        worker.run_cycle(None)
+        assert worker.interval == expected_interval
+
+
+def test_first_export_fires_shortly_after_start(
+    spool: Spool, otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 0.05)
+    worker = make_worker(spool, otlp_server.url)
+    spool.append("traces", b"early-payload")
+    worker.start()
+    try:
+        assert unwrap(worker.thread).name == "ApitallyExportWorker"
+        deadline = time.time() + 5
+        while not otlp_server.requests and time.time() < deadline:
+            time.sleep(0.01)
+    finally:
+        worker.stop()
+    assert otlp_server.paths() == ["/v1/traces"]
+
+
+def test_export_cycle_suppresses_instrumentation(spool: Spool, otlp_server: StubOTLPServer) -> None:
+    set_config(write_token=WRITE_TOKEN, env="dev", otlp_endpoint=otlp_server.url)
+    suppressed_flags: list[bool] = []
+    processor_stub = SimpleNamespace(
+        downstream=SimpleNamespace(
+            force_flush=lambda timeout_millis=30_000: suppressed_flags.append(not is_instrumentation_enabled())
+        )
+    )
+    worker = ExportWorker(spool, cast("Any", processor_stub), cast("Any", processor_stub), env="dev")
+    worker.session.hooks["response"] = [
+        lambda response, **kwargs: suppressed_flags.append(not is_instrumentation_enabled())
+    ]
+    spool.append("traces", b"trace-payload")
+    worker.run_cycle(None)
+    assert suppressed_flags == [True, True, True]
+    assert is_instrumentation_enabled()
+
+
+def test_shutdown_performs_final_drain_and_stops_thread(
+    spool: Spool, otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 60.0)
+    worker = make_worker(spool, otlp_server.url)
+    worker.start()
+    spool.append("traces", b"final-payload")
+    worker.shutdown()
+    assert unwrap(worker.thread).is_alive() is False
+    assert otlp_server.paths() == ["/v1/traces"]
+    assert spool.pending_files() == []

--- a/tests/shared/test_metrics.py
+++ b/tests/shared/test_metrics.py
@@ -1,6 +1,10 @@
+import gzip
+import logging
+import threading
 from collections.abc import Iterator
 
 import pytest
+from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
 from opentelemetry.sdk.metrics import Histogram as SDKHistogram
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
@@ -13,13 +17,21 @@ from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation
 from opentelemetry.sdk.resources import Resource
 
 from apitally.shared import metrics
-from tests.conftest import attach_metric_reader, collect_metrics
+from apitally.shared.spool import Spool
+from tests.conftest import attach_metric_reader, collect_metrics, unwrap
 
 
 @pytest.fixture(autouse=True)
 def reset_metrics() -> Iterator[None]:
     yield
     metrics.reset()
+
+
+@pytest.fixture
+def spool() -> Iterator[Spool]:
+    spool = Spool()
+    yield spool
+    spool.clear()
 
 
 def create_pipeline() -> InMemoryMetricReader:
@@ -72,20 +84,59 @@ def test_histograms_under_apitally_scope():
     assert get_scope_names(reader)["http.server.request.duration"] == "apitally"
 
 
-def test_export_interval_ignores_env(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("OTEL_METRIC_EXPORT_INTERVAL", "5000")
+def test_reader_keeps_histogram_temporality_and_aggregation(spool: Spool):
     provider = metrics.setup(Resource.create({}))
-    metrics.attach_reader("prod")
+    metrics.attach_reader(spool)
     reader = metrics.reader
     assert reader is not None
     assert reader in provider._all_metric_readers
-    assert reader._export_interval_millis == 60_000
     # The reader re-keys the overrides onto internal instrument base classes
     histogram_key = next(cls for cls in reader._instrument_class_temporality if issubclass(cls, SDKHistogram))
     assert reader._instrument_class_temporality[histogram_key] == AggregationTemporality.DELTA
     aggregation = reader._instrument_class_aggregation[histogram_key]
     assert isinstance(aggregation, ExponentialBucketHistogramAggregation)
     assert aggregation._max_scale == 3
+
+
+def test_collect_appends_delta_payloads_to_spool(spool: Spool):
+    metrics.setup(Resource.create({}))
+    metrics.attach_reader(spool)
+    metrics.record_request("GET", "/a", 200, consumer=None, duration=1.0)
+    unwrap(metrics.reader).collect()
+    metrics.record_request("GET", "/a", 200, consumer=None, duration=2.0)
+    unwrap(metrics.reader).collect()
+    spool.rotate_for_export()
+    (file,) = [file for file in spool.pending_files() if file.signal == "metrics"]
+    request = ExportMetricsServiceRequest.FromString(gzip.decompress(file.read_bytes()))
+    assert len(request.resource_metrics) == 2
+    points = [
+        point
+        for rm in request.resource_metrics
+        for sm in rm.scope_metrics
+        for metric in sm.metrics
+        if metric.name == "http.server.request.duration"
+        for point in metric.exponential_histogram.data_points
+    ]
+    assert [point.count for point in points] == [1, 1]
+    assert sum(point.sum for point in points) == pytest.approx(3.0)
+
+
+def test_no_timer_thread_after_attach(spool: Spool):
+    threads_before = {thread.ident for thread in threading.enumerate()}
+    metrics.setup(Resource.create({}))
+    metrics.attach_reader(spool)
+    assert {thread.ident for thread in threading.enumerate()} == threads_before
+
+
+def test_detach_then_collect_is_a_noop_without_warnings(spool: Spool, caplog: pytest.LogCaptureFixture):
+    metrics.setup(Resource.create({}))
+    metrics.attach_reader(spool)
+    reader = unwrap(metrics.reader)
+    metrics.detach_reader()
+    with caplog.at_level(logging.WARNING):
+        reader.collect()
+    assert not caplog.records
+    assert not spool.pending_files()
 
 
 def test_consumer_identifier_attribute():

--- a/tests/shared/test_metrics.py
+++ b/tests/shared/test_metrics.py
@@ -1,4 +1,3 @@
-import gzip
 import logging
 import threading
 from collections.abc import Iterator
@@ -16,7 +15,7 @@ from opentelemetry.sdk.resources import Resource
 
 from apitally.shared import metrics
 from apitally.shared.spool import Spool
-from tests.conftest import attach_metric_reader, collect_metrics, read_spool_file, unwrap
+from tests.conftest import attach_metric_reader, collect_metrics, read_spool_payload, unwrap
 
 
 @pytest.fixture(autouse=True)
@@ -91,7 +90,7 @@ def test_collect_appends_delta_payloads_to_spool(spool: Spool):
     unwrap(metrics.reader).collect()
     spool.rotate_for_export()
     (file,) = [file for file in spool.pending_files() if file.signal == "metrics"]
-    request = ExportMetricsServiceRequest.FromString(gzip.decompress(read_spool_file(file)))
+    request = ExportMetricsServiceRequest.FromString(read_spool_payload(file))
     assert len(request.resource_metrics) == 2
     points = [
         point

--- a/tests/shared/test_metrics.py
+++ b/tests/shared/test_metrics.py
@@ -5,7 +5,6 @@ from collections.abc import Iterator
 
 import pytest
 from opentelemetry.proto.collector.metrics.v1.metrics_service_pb2 import ExportMetricsServiceRequest
-from opentelemetry.sdk.metrics import Histogram as SDKHistogram
 from opentelemetry.sdk.metrics.export import (
     AggregationTemporality,
     ExponentialHistogram,
@@ -13,12 +12,11 @@ from opentelemetry.sdk.metrics.export import (
     InMemoryMetricReader,
     Sum,
 )
-from opentelemetry.sdk.metrics.view import ExponentialBucketHistogramAggregation
 from opentelemetry.sdk.resources import Resource
 
 from apitally.shared import metrics
 from apitally.shared.spool import Spool
-from tests.conftest import attach_metric_reader, collect_metrics, unwrap
+from tests.conftest import attach_metric_reader, collect_metrics, read_spool_file, unwrap
 
 
 @pytest.fixture(autouse=True)
@@ -84,20 +82,6 @@ def test_histograms_under_apitally_scope():
     assert get_scope_names(reader)["http.server.request.duration"] == "apitally"
 
 
-def test_reader_keeps_histogram_temporality_and_aggregation(spool: Spool):
-    provider = metrics.setup(Resource.create({}))
-    metrics.attach_reader(spool)
-    reader = metrics.reader
-    assert reader is not None
-    assert reader in provider._all_metric_readers
-    # The reader re-keys the overrides onto internal instrument base classes
-    histogram_key = next(cls for cls in reader._instrument_class_temporality if issubclass(cls, SDKHistogram))
-    assert reader._instrument_class_temporality[histogram_key] == AggregationTemporality.DELTA
-    aggregation = reader._instrument_class_aggregation[histogram_key]
-    assert isinstance(aggregation, ExponentialBucketHistogramAggregation)
-    assert aggregation._max_scale == 3
-
-
 def test_collect_appends_delta_payloads_to_spool(spool: Spool):
     metrics.setup(Resource.create({}))
     metrics.attach_reader(spool)
@@ -107,7 +91,7 @@ def test_collect_appends_delta_payloads_to_spool(spool: Spool):
     unwrap(metrics.reader).collect()
     spool.rotate_for_export()
     (file,) = [file for file in spool.pending_files() if file.signal == "metrics"]
-    request = ExportMetricsServiceRequest.FromString(gzip.decompress(file.read_bytes()))
+    request = ExportMetricsServiceRequest.FromString(gzip.decompress(read_spool_file(file)))
     assert len(request.resource_metrics) == 2
     points = [
         point

--- a/tests/shared/test_providers.py
+++ b/tests/shared/test_providers.py
@@ -113,8 +113,6 @@ def test_endpoint_override_ignores_otel_env_vars(monkeypatch: pytest.MonkeyPatch
 
 
 def test_pipeline_delivers_to_otlp_endpoint(otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch):
-    # Runs the real pipeline against a local HTTP server: spans, logs and metrics reach
-    # the spool and one export cycle delivers them as gzipped protobuf
     monkeypatch.setenv("APITALLY_OTLP_ENDPOINT", otlp_server.url)
     monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
     monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 60.0)

--- a/tests/shared/test_providers.py
+++ b/tests/shared/test_providers.py
@@ -1,8 +1,6 @@
+import gzip
 import logging
-import threading
 import uuid
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
-from typing import Any
 
 import pytest
 from opentelemetry import metrics, trace
@@ -17,10 +15,10 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.trace import SpanKind
 
-from apitally.shared import activation, providers
+from apitally.shared import activation, export, providers
 from apitally.shared import metrics as apitally_metrics
 from apitally.shared.config import set_config
-from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, unwrap
+from tests.conftest import CONTRIB_SCOPE, WRITE_TOKEN, StubOTLPServer, unwrap
 
 
 def test_user_tracer_provider_detection():
@@ -86,76 +84,56 @@ def test_env_conflict_uses_user_resource_value():
     assert env == "production"
 
 
-def test_apitally_env_header_matches_resource_with_and_without_user_provider():
+def test_export_headers_match_resource_env_with_and_without_user_provider():
     set_config(write_token=WRITE_TOKEN, env="staging")
 
     env = providers.resolve_env(None)
     resource = providers.create_resource(env)
-    exporter = providers.create_span_exporter(env)
-    assert exporter._headers["Apitally-Env"] == resource.attributes["deployment.environment.name"] == "staging"
-    assert exporter._headers["Authorization"] == f"Bearer {WRITE_TOKEN}"
-    assert exporter._endpoint == "https://otlp.apitally.io/v1/traces"
+    headers = providers.export_headers(env)
+    assert headers["Apitally-Env"] == resource.attributes["deployment.environment.name"] == "staging"
+    assert headers["Authorization"] == f"Bearer {WRITE_TOKEN}"
+    assert providers.endpoint_url("/v1/traces") == "https://otlp.apitally.io/v1/traces"
 
     user_provider = TracerProvider(resource=Resource.create({"deployment.environment.name": "production"}))
     env = providers.resolve_env(user_provider)
-    log_exporter = providers.create_log_exporter(env)
-    assert log_exporter._headers["Apitally-Env"] == "production"
+    assert providers.export_headers(env)["Apitally-Env"] == "production"
 
 
-def test_exporter_endpoint_override(monkeypatch: pytest.MonkeyPatch):
+def test_endpoint_override_ignores_otel_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("APITALLY_OTLP_ENDPOINT", "http://localhost:4318")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_ENDPOINT", "https://collector.example.com")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_TRACES_ENDPOINT", "https://collector.example.com/v1/traces")
     monkeypatch.setenv("OTEL_EXPORTER_OTLP_HEADERS", "x-other=1")
     set_config(write_token=WRITE_TOKEN)
 
-    span_exporter = providers.create_span_exporter("prod")
-    metric_exporter = providers.create_metric_exporter("prod")
-    log_exporter = providers.create_log_exporter("prod")
-    assert span_exporter._endpoint == "http://localhost:4318/v1/traces"
-    assert metric_exporter._endpoint == "http://localhost:4318/v1/metrics"
-    assert log_exporter._endpoint == "http://localhost:4318/v1/logs"
-    assert "x-other" not in span_exporter._headers
+    assert providers.endpoint_url("/v1/traces") == "http://localhost:4318/v1/traces"
+    assert providers.endpoint_url("/v1/metrics") == "http://localhost:4318/v1/metrics"
+    assert providers.endpoint_url("/v1/logs") == "http://localhost:4318/v1/logs"
+    assert "x-other" not in providers.export_headers("prod")
 
 
-def test_exporters_deliver_to_otlp_endpoint(monkeypatch: pytest.MonkeyPatch):
-    # The endpoint/header assertions above read private exporter attributes; this test runs
-    # real exporters posting protobuf over HTTP, so it catches changes in the OTel SDK
-    received: dict[str, tuple[Any, bytes]] = {}
+def test_pipeline_delivers_to_otlp_endpoint(otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch):
+    # Runs the real pipeline against a local HTTP server: spans, logs and metrics reach
+    # the spool and one export cycle delivers them as gzipped protobuf
+    monkeypatch.setenv("APITALLY_OTLP_ENDPOINT", otlp_server.url)
+    monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 60.0)
+    activation.configure(write_token=WRITE_TOKEN, env="ci")
+    activation.activate()
 
-    class Handler(BaseHTTPRequestHandler):
-        def do_POST(self) -> None:
-            body = self.rfile.read(int(self.headers.get("Content-Length") or 0))
-            received[self.path] = (self.headers, body)
-            self.send_response(200)
-            self.end_headers()
+    with trace.get_tracer(CONTRIB_SCOPE).start_as_current_span("GET /items", kind=SpanKind.SERVER):
+        logging.getLogger("myapp").warning("hello")
+    apitally_metrics.record_request(method="GET", route="/items", status_code=200, consumer=None, duration=0.1)
+    unwrap(activation.export_worker).run_cycle(None)
 
-        def log_message(self, format: str, *args: Any) -> None:
-            pass
-
-    with ThreadingHTTPServer(("127.0.0.1", 0), Handler) as server:
-        threading.Thread(target=server.serve_forever, daemon=True).start()
-        monkeypatch.setenv("APITALLY_OTLP_ENDPOINT", f"http://127.0.0.1:{server.server_port}")
-        monkeypatch.delenv("PYTEST_CURRENT_TEST", raising=False)
-        activation.configure(write_token=WRITE_TOKEN, env="ci")
-        activation.activate()
-
-        with trace.get_tracer(CONTRIB_SCOPE).start_as_current_span("GET /items", kind=SpanKind.SERVER):
-            logging.getLogger("myapp").warning("hello")
-        apitally_metrics.record_request(method="GET", route="/items", status_code=200, consumer=None, duration=0.1)
-
-        unwrap(activation.span_processor).force_flush()
-        unwrap(activation.log_processor).force_flush()
-        unwrap(apitally_metrics.reader).force_flush()
-        server.shutdown()
-
-    assert set(received) == {"/v1/traces", "/v1/metrics", "/v1/logs"}
-    for headers, _ in received.values():
+    assert set(otlp_server.paths()) == {"/v1/traces", "/v1/metrics", "/v1/logs"}
+    for _, headers, _ in otlp_server.requests:
         assert headers["Authorization"] == f"Bearer {WRITE_TOKEN}"
         assert headers["Apitally-Env"] == "ci"
+        assert headers["Content-Encoding"] == "gzip"
 
-    trace_request = ExportTraceServiceRequest()
-    trace_request.ParseFromString(received["/v1/traces"][1])
+    (trace_body,) = [body for path, _, body in otlp_server.requests if path == "/v1/traces"]
+    trace_request = ExportTraceServiceRequest.FromString(gzip.decompress(trace_body))
     (span,) = [s for rs in trace_request.resource_spans for ss in rs.scope_spans for s in ss.spans]
     assert span.name == "GET /items"
 

--- a/tests/shared/test_spool.py
+++ b/tests/shared/test_spool.py
@@ -1,0 +1,185 @@
+import gzip
+import logging
+import os
+import tempfile
+import time
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+from opentelemetry.proto.collector.trace.v1.trace_service_pb2 import ExportTraceServiceRequest
+from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Span
+
+from apitally.shared import spool as spool_module
+from apitally.shared.spool import (
+    ROTATE_AT_UNCOMPRESSED_SIZE,
+    SEND_HORIZON,
+    Spool,
+    SpoolFile,
+    cleanup_orphaned_files,
+)
+
+
+@pytest.fixture(autouse=True)
+def reset_duplicate_log_filter() -> Iterator[None]:
+    spool_module.duplicate_log_filter.last_logged.clear()
+    yield
+
+
+@pytest.fixture(params=["disk", "memory"])
+def spool(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Iterator[Spool]:
+    if request.param == "memory":
+        monkeypatch.setattr(spool_module, "check_writable_fs", lambda: False)
+    spool = Spool()
+    yield spool
+    spool.clear()
+
+
+def serialized_trace_request(span_name: str) -> bytes:
+    return ExportTraceServiceRequest(
+        resource_spans=[ResourceSpans(scope_spans=[ScopeSpans(spans=[Span(name=span_name)])])]
+    ).SerializeToString()
+
+
+def parse_file(file: SpoolFile) -> ExportTraceServiceRequest:
+    return ExportTraceServiceRequest.FromString(gzip.decompress(file.read_bytes()))
+
+
+def test_concatenated_payloads_parse_as_one_merged_request(spool: Spool) -> None:
+    spool.append("traces", serialized_trace_request("first"))
+    spool.append("traces", serialized_trace_request("second"))
+    spool.rotate_for_export()
+    (file,) = spool.pending_files()
+    request = parse_file(file)
+    assert len(request.resource_spans) == 2
+    span_names = {span.name for rs in request.resource_spans for ss in rs.scope_spans for span in ss.spans}
+    assert span_names == {"first", "second"}
+
+
+def test_closed_file_bytes_are_stable_across_reads(spool: Spool) -> None:
+    spool.append("traces", serialized_trace_request("span"))
+    spool.rotate_for_export()
+    (file,) = spool.pending_files()
+    assert file.read_bytes() == file.read_bytes()
+
+
+def test_append_rotates_before_crossing_size_threshold(spool: Spool) -> None:
+    spool.append("traces", b"a" * 3_000_000)
+    spool.append("traces", b"b" * 2_000_000)
+    (file,) = spool.pending_files()
+    assert file.uncompressed_size <= ROTATE_AT_UNCOMPRESSED_SIZE
+    assert gzip.decompress(file.read_bytes()) == b"a" * 3_000_000
+    assert spool.current["traces"].uncompressed_size == 2_000_000
+
+
+def test_export_rotation_skipped_while_signal_has_backlog(spool: Spool) -> None:
+    spool.append("traces", b"first")
+    spool.rotate_for_export()
+    assert len(spool.pending_files()) == 1
+    spool.append("traces", b"second")
+    spool.rotate_for_export()
+    assert len(spool.pending_files()) == 1
+    assert "traces" in spool.current
+
+
+def test_attempted_file_expires_after_send_horizon(spool: Spool) -> None:
+    for signal in ("traces", "metrics", "logs"):
+        spool.append(signal, b"payload")
+    spool.rotate_for_export()
+    files = {file.signal: file for file in spool.pending_files()}
+    for signal in ("traces", "metrics"):
+        files[signal].first_attempt_at = time.time() - SEND_HORIZON - 1
+    files["logs"].created_at = time.time() - 10 * 60 * 60
+    spool.rotate_for_export()
+    assert [file.signal for file in spool.pending_files()] == ["logs"]
+    for signal in ("traces", "metrics"):
+        if files[signal].path is not None:
+            assert not files[signal].path.exists()
+
+
+def test_size_cap_evicts_oldest_non_metrics_first(spool: Spool) -> None:
+    spool.append("metrics", os.urandom(10_000))
+    spool.rotate_for_export()
+    spool.append("traces", os.urandom(10_000))
+    spool.append("logs", os.urandom(10_000))
+    spool.rotate_for_export()
+    files = spool.pending_files()
+    assert [file.signal for file in files] == ["metrics", "traces", "logs"]
+    spool.max_size = sum(file.compressed_size for file in files) - 1
+    spool.rotate_for_export()
+    assert [file.signal for file in spool.pending_files()] == ["metrics", "logs"]
+
+
+def test_writability_probe_failure_falls_back_to_memory_with_single_warning(
+    monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setattr(spool_module, "check_writable_fs", lambda: False)
+    with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
+        spool = Spool()
+    assert spool.in_memory
+    assert len(caplog.records) == 1
+    assert "memory" in caplog.records[0].message
+    spool.append("traces", b"payload")
+    spool.rotate_for_export()
+    (file,) = spool.pending_files()
+    assert file.path is None
+    assert gzip.decompress(file.read_bytes()) == b"payload"
+    spool.clear()
+
+
+def test_append_error_discards_current_file_and_recovers(
+    spool: Spool, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    spool.append("traces", b"first")
+    failed_file = spool.current["traces"]
+    with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
+        with monkeypatch.context() as patched:
+
+            def raise_oserror(self: SpoolFile, payload: bytes) -> None:
+                raise OSError("disk full")
+
+            patched.setattr(SpoolFile, "write", raise_oserror)
+            spool.append("traces", b"second")
+    assert len(caplog.records) == 1
+    assert "traces" not in spool.current
+    if failed_file.path is not None:
+        assert not failed_file.path.exists()
+    spool.append("traces", b"third")
+    spool.rotate_for_export()
+    (file,) = spool.pending_files()
+    assert gzip.decompress(file.read_bytes()) == b"third"
+
+
+def test_orphan_cleanup_removes_stale_files_only() -> None:
+    stale = tempfile.NamedTemporaryFile(prefix="apitally-", suffix=".gz", delete=False)
+    fresh = tempfile.NamedTemporaryFile(prefix="apitally-", suffix=".gz", delete=False)
+    stale.close()
+    fresh.close()
+    try:
+        old_time = time.time() - 3 * 60 * 60
+        os.utime(stale.name, (old_time, old_time))
+        cleanup_orphaned_files()
+        assert not Path(stale.name).exists()
+        assert Path(fresh.name).exists()
+    finally:
+        Path(stale.name).unlink(missing_ok=True)
+        Path(fresh.name).unlink(missing_ok=True)
+
+
+def test_liveness_touch_shields_files_from_orphan_cleanup() -> None:
+    spool = Spool()
+    try:
+        spool.append("traces", b"first")
+        spool.rotate_for_export()
+        spool.append("traces", b"second")
+        paths = [file.path for file in (*spool.pending_files(), spool.current["traces"])]
+        old_time = time.time() - 3 * 60 * 60
+        for path in paths:
+            assert path is not None
+            os.utime(path, (old_time, old_time))
+        spool.touch_files()
+        cleanup_orphaned_files()
+        for path in paths:
+            assert path is not None and path.exists()
+    finally:
+        spool.clear()

--- a/tests/shared/test_spool.py
+++ b/tests/shared/test_spool.py
@@ -130,7 +130,6 @@ def test_attempted_file_expires_after_send_horizon(spool: Spool, caplog: pytest.
     files = {file.signal: file for file in spool.pending_files()}
     for signal in ("traces", "metrics"):
         files[signal].first_attempt_at = time.monotonic() - SEND_HORIZON - 1
-    files["logs"].created_at = time.time() - 10 * 60 * 60
     with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
         spool.rotate_for_export()
     assert [file.signal for file in spool.pending_files()] == ["logs"]

--- a/tests/shared/test_spool.py
+++ b/tests/shared/test_spool.py
@@ -12,24 +12,19 @@ from opentelemetry.proto.trace.v1.trace_pb2 import ResourceSpans, ScopeSpans, Sp
 
 from apitally.shared import spool as spool_module
 from apitally.shared.spool import (
-    ROTATE_AT_UNCOMPRESSED_SIZE,
-    SEND_HORIZON,
+    MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT,
+    MAX_UNCOMPRESSED_FILE_SIZE,
     Spool,
     SpoolFile,
     cleanup_orphaned_files,
 )
-
-
-@pytest.fixture(autouse=True)
-def reset_duplicate_log_filter() -> Iterator[None]:
-    spool_module.duplicate_log_filter.last_logged.clear()
-    yield
+from tests.conftest import read_spool_file
 
 
 @pytest.fixture(params=["disk", "memory"])
 def spool(request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch) -> Iterator[Spool]:
     if request.param == "memory":
-        monkeypatch.setattr(spool_module, "check_writable_fs", lambda: False)
+        monkeypatch.setattr(spool_module, "is_temp_dir_writable", lambda: False)
     spool = Spool()
     yield spool
     spool.clear()
@@ -42,7 +37,7 @@ def serialized_trace_request(span_name: str) -> bytes:
 
 
 def parse_file(file: SpoolFile) -> ExportTraceServiceRequest:
-    return ExportTraceServiceRequest.FromString(gzip.decompress(file.read_bytes()))
+    return ExportTraceServiceRequest.FromString(gzip.decompress(read_spool_file(file)))
 
 
 def test_concatenated_payloads_parse_as_one_merged_request(spool: Spool) -> None:
@@ -56,17 +51,7 @@ def test_concatenated_payloads_parse_as_one_merged_request(spool: Spool) -> None
     assert span_names == {"first", "second"}
 
 
-def test_closed_file_bytes_are_stable_across_reads(spool: Spool) -> None:
-    spool.append("traces", serialized_trace_request("span"))
-    spool.rotate_for_export()
-    (file,) = spool.pending_files()
-    assert file.read_bytes() == file.read_bytes()
-
-
 def test_closed_file_is_fully_flushed_to_disk() -> None:
-    # A closed file must have all bytes on disk, not in the Python-level buffer: buffered
-    # bytes shared with a forked child through the inherited file descriptor get flushed
-    # by both processes and corrupt the file
     spool = Spool()
     try:
         spool.append("traces", b"payload")
@@ -85,14 +70,13 @@ def test_rotation_error_discards_current_file_and_recovers(
 ) -> None:
     spool.append("traces", b"first")
     failed_file = spool.current["traces"]
+
+    def raise_oserror(*args: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(failed_file.gzip_stream, "close", raise_oserror)
     with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
-        with monkeypatch.context() as patched:
-
-            def raise_oserror(self: SpoolFile) -> None:
-                raise OSError("disk full")
-
-            patched.setattr(SpoolFile, "close", raise_oserror)
-            spool.rotate_for_export()
+        spool.rotate_for_export()
     assert len(caplog.records) == 1
     assert "traces" not in spool.current
     assert spool.pending_files() == []
@@ -101,43 +85,31 @@ def test_rotation_error_discards_current_file_and_recovers(
     spool.append("traces", b"second")
     spool.rotate_for_export()
     (file,) = spool.pending_files()
-    assert gzip.decompress(file.read_bytes()) == b"second"
+    assert gzip.decompress(read_spool_file(file)) == b"second"
 
 
 def test_append_rotates_before_crossing_size_threshold(spool: Spool) -> None:
     spool.append("traces", b"a" * 3_000_000)
     spool.append("traces", b"b" * 2_000_000)
     (file,) = spool.pending_files()
-    assert file.uncompressed_size <= ROTATE_AT_UNCOMPRESSED_SIZE
-    assert gzip.decompress(file.read_bytes()) == b"a" * 3_000_000
+    assert file.uncompressed_size <= MAX_UNCOMPRESSED_FILE_SIZE
+    assert gzip.decompress(read_spool_file(file)) == b"a" * 3_000_000
     assert spool.current["traces"].uncompressed_size == 2_000_000
 
 
-def test_export_rotation_skipped_while_signal_has_backlog(spool: Spool) -> None:
-    spool.append("traces", b"first")
-    spool.rotate_for_export()
-    assert len(spool.pending_files()) == 1
-    spool.append("traces", b"second")
-    spool.rotate_for_export()
-    assert len(spool.pending_files()) == 1
-    assert "traces" in spool.current
-
-
-def test_attempted_file_expires_after_send_horizon(spool: Spool, caplog: pytest.LogCaptureFixture) -> None:
+def test_attempted_file_expires_after_max_retry_time(spool: Spool, caplog: pytest.LogCaptureFixture) -> None:
     for signal in ("traces", "metrics", "logs"):
         spool.append(signal, b"payload")
     spool.rotate_for_export()
     files = {file.signal: file for file in spool.pending_files()}
     for signal in ("traces", "metrics"):
-        files[signal].first_attempt_at = time.monotonic() - SEND_HORIZON - 1
+        files[signal].first_attempt_at = time.monotonic() - MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT - 1
     with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
         spool.rotate_for_export()
     assert [file.signal for file in spool.pending_files()] == ["logs"]
     for signal in ("traces", "metrics"):
-        if files[signal].path is not None:
-            assert not files[signal].path.exists()
-    # One data-loss warning per signal: the duplicate filter must not swallow a warning
-    # that differs only in its arguments
+        if (path := files[signal].path) is not None:
+            assert not path.exists()
     eviction_warnings = [record.getMessage() for record in caplog.records if "dropped" in record.message]
     assert len(eviction_warnings) == 2
     assert any("traces" in message for message in eviction_warnings)
@@ -157,10 +129,10 @@ def test_size_cap_evicts_oldest_non_metrics_first(spool: Spool) -> None:
     assert [file.signal for file in spool.pending_files()] == ["metrics", "logs"]
 
 
-def test_writability_probe_failure_falls_back_to_memory_with_single_warning(
+def test_unwritable_temp_dir_falls_back_to_memory(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    monkeypatch.setattr(spool_module, "check_writable_fs", lambda: False)
+    monkeypatch.setattr(spool_module, "is_temp_dir_writable", lambda: False)
     with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
         spool = Spool()
     assert spool.in_memory
@@ -170,7 +142,7 @@ def test_writability_probe_failure_falls_back_to_memory_with_single_warning(
     spool.rotate_for_export()
     (file,) = spool.pending_files()
     assert file.path is None
-    assert gzip.decompress(file.read_bytes()) == b"payload"
+    assert gzip.decompress(read_spool_file(file)) == b"payload"
     spool.clear()
 
 
@@ -179,14 +151,13 @@ def test_append_error_discards_current_file_and_recovers(
 ) -> None:
     spool.append("traces", b"first")
     failed_file = spool.current["traces"]
+
+    def raise_oserror(*args: object) -> None:
+        raise OSError("disk full")
+
+    monkeypatch.setattr(failed_file.gzip_stream, "write", raise_oserror)
     with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
-        with monkeypatch.context() as patched:
-
-            def raise_oserror(self: SpoolFile, payload: bytes) -> None:
-                raise OSError("disk full")
-
-            patched.setattr(SpoolFile, "write", raise_oserror)
-            spool.append("traces", b"second")
+        spool.append("traces", b"second")
     assert len(caplog.records) == 1
     assert "traces" not in spool.current
     if failed_file.path is not None:
@@ -194,39 +165,27 @@ def test_append_error_discards_current_file_and_recovers(
     spool.append("traces", b"third")
     spool.rotate_for_export()
     (file,) = spool.pending_files()
-    assert gzip.decompress(file.read_bytes()) == b"third"
+    assert gzip.decompress(read_spool_file(file)) == b"third"
 
 
-def test_orphan_cleanup_removes_stale_files_only() -> None:
-    stale = tempfile.NamedTemporaryFile(prefix="apitally-", suffix=".gz", delete=False)
-    fresh = tempfile.NamedTemporaryFile(prefix="apitally-", suffix=".gz", delete=False)
-    stale.close()
-    fresh.close()
-    try:
-        old_time = time.time() - 3 * 60 * 60
-        os.utime(stale.name, (old_time, old_time))
-        cleanup_orphaned_files()
-        assert not Path(stale.name).exists()
-        assert Path(fresh.name).exists()
-    finally:
-        Path(stale.name).unlink(missing_ok=True)
-        Path(fresh.name).unlink(missing_ok=True)
-
-
-def test_liveness_touch_shields_files_from_orphan_cleanup() -> None:
+def test_orphan_cleanup_removes_untouched_stale_files_only() -> None:
+    orphan = tempfile.NamedTemporaryFile(prefix="apitally-", suffix=".gz", delete=False)
+    orphan.close()
     spool = Spool()
     try:
         spool.append("traces", b"first")
         spool.rotate_for_export()
         spool.append("traces", b"second")
-        paths = [file.path for file in (*spool.pending_files(), spool.current["traces"])]
+        spool_paths = [file.path for file in (*spool.pending_files(), spool.current["traces"])]
         old_time = time.time() - 3 * 60 * 60
-        for path in paths:
+        for path in (orphan.name, *spool_paths):
             assert path is not None
             os.utime(path, (old_time, old_time))
         spool.touch_files()
         cleanup_orphaned_files()
-        for path in paths:
+        assert not Path(orphan.name).exists()
+        for path in spool_paths:
             assert path is not None and path.exists()
     finally:
+        Path(orphan.name).unlink(missing_ok=True)
         spool.clear()

--- a/tests/shared/test_spool.py
+++ b/tests/shared/test_spool.py
@@ -18,7 +18,7 @@ from apitally.shared.spool import (
     SpoolFile,
     cleanup_orphaned_files,
 )
-from tests.conftest import read_spool_file
+from tests.conftest import read_spool_payload
 
 
 @pytest.fixture(params=["disk", "memory"])
@@ -37,7 +37,7 @@ def serialized_trace_request(span_name: str) -> bytes:
 
 
 def parse_file(file: SpoolFile) -> ExportTraceServiceRequest:
-    return ExportTraceServiceRequest.FromString(gzip.decompress(read_spool_file(file)))
+    return ExportTraceServiceRequest.FromString(read_spool_payload(file))
 
 
 def test_concatenated_payloads_parse_as_one_merged_request(spool: Spool) -> None:
@@ -85,7 +85,7 @@ def test_rotation_error_discards_current_file_and_recovers(
     spool.append("traces", b"second")
     spool.rotate_for_export()
     (file,) = spool.pending_files()
-    assert gzip.decompress(read_spool_file(file)) == b"second"
+    assert read_spool_payload(file) == b"second"
 
 
 def test_append_rotates_before_crossing_size_threshold(spool: Spool) -> None:
@@ -93,7 +93,7 @@ def test_append_rotates_before_crossing_size_threshold(spool: Spool) -> None:
     spool.append("traces", b"b" * 2_000_000)
     (file,) = spool.pending_files()
     assert file.uncompressed_size <= MAX_UNCOMPRESSED_FILE_SIZE
-    assert gzip.decompress(read_spool_file(file)) == b"a" * 3_000_000
+    assert read_spool_payload(file) == b"a" * 3_000_000
     assert spool.current["traces"].uncompressed_size == 2_000_000
 
 
@@ -148,7 +148,7 @@ def test_unwritable_temp_dir_falls_back_to_memory(
     spool.rotate_for_export()
     (file,) = spool.pending_files()
     assert file.path is None
-    assert gzip.decompress(read_spool_file(file)) == b"payload"
+    assert read_spool_payload(file) == b"payload"
     spool.clear()
 
 
@@ -171,7 +171,7 @@ def test_append_error_discards_current_file_and_recovers(
     spool.append("traces", b"third")
     spool.rotate_for_export()
     (file,) = spool.pending_files()
-    assert gzip.decompress(read_spool_file(file)) == b"third"
+    assert read_spool_payload(file) == b"third"
 
 
 def test_orphan_cleanup_removes_untouched_stale_files_only() -> None:

--- a/tests/shared/test_spool.py
+++ b/tests/shared/test_spool.py
@@ -127,12 +127,18 @@ def test_size_cap_evicts_oldest_non_metrics_first(spool: Spool) -> None:
     spool.max_size = sum(file.compressed_size for file in files) - 1
     spool.rotate_for_export()
     assert [file.signal for file in spool.pending_files()] == ["metrics", "logs"]
+    spool.max_size = 0
+    spool.rotate_for_export()
+    assert [file.signal for file in spool.pending_files()] == ["metrics"]
 
 
 def test_unwritable_temp_dir_falls_back_to_memory(
     monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
 ) -> None:
-    monkeypatch.setattr(spool_module, "is_temp_dir_writable", lambda: False)
+    def raise_oserror(*args: object, **kwargs: object) -> None:
+        raise OSError("read-only file system")
+
+    monkeypatch.setattr(tempfile, "NamedTemporaryFile", raise_oserror)
     with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
         spool = Spool()
     assert spool.in_memory

--- a/tests/shared/test_spool.py
+++ b/tests/shared/test_spool.py
@@ -63,6 +63,47 @@ def test_closed_file_bytes_are_stable_across_reads(spool: Spool) -> None:
     assert file.read_bytes() == file.read_bytes()
 
 
+def test_closed_file_is_fully_flushed_to_disk() -> None:
+    # A closed file must have all bytes on disk, not in the Python-level buffer: buffered
+    # bytes shared with a forked child through the inherited file descriptor get flushed
+    # by both processes and corrupt the file
+    spool = Spool()
+    try:
+        spool.append("traces", b"payload")
+        spool.rotate_for_export()
+        (file,) = spool.pending_files()
+        assert file.path is not None
+        assert file.compressed_size > 0
+        assert os.stat(file.path).st_size == file.compressed_size
+        assert gzip.decompress(file.path.read_bytes()) == b"payload"
+    finally:
+        spool.clear()
+
+
+def test_rotation_error_discards_current_file_and_recovers(
+    spool: Spool, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    spool.append("traces", b"first")
+    failed_file = spool.current["traces"]
+    with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
+        with monkeypatch.context() as patched:
+
+            def raise_oserror(self: SpoolFile) -> None:
+                raise OSError("disk full")
+
+            patched.setattr(SpoolFile, "close", raise_oserror)
+            spool.rotate_for_export()
+    assert len(caplog.records) == 1
+    assert "traces" not in spool.current
+    assert spool.pending_files() == []
+    if failed_file.path is not None:
+        assert not failed_file.path.exists()
+    spool.append("traces", b"second")
+    spool.rotate_for_export()
+    (file,) = spool.pending_files()
+    assert gzip.decompress(file.read_bytes()) == b"second"
+
+
 def test_append_rotates_before_crossing_size_threshold(spool: Spool) -> None:
     spool.append("traces", b"a" * 3_000_000)
     spool.append("traces", b"b" * 2_000_000)
@@ -82,19 +123,26 @@ def test_export_rotation_skipped_while_signal_has_backlog(spool: Spool) -> None:
     assert "traces" in spool.current
 
 
-def test_attempted_file_expires_after_send_horizon(spool: Spool) -> None:
+def test_attempted_file_expires_after_send_horizon(spool: Spool, caplog: pytest.LogCaptureFixture) -> None:
     for signal in ("traces", "metrics", "logs"):
         spool.append(signal, b"payload")
     spool.rotate_for_export()
     files = {file.signal: file for file in spool.pending_files()}
     for signal in ("traces", "metrics"):
-        files[signal].first_attempt_at = time.time() - SEND_HORIZON - 1
+        files[signal].first_attempt_at = time.monotonic() - SEND_HORIZON - 1
     files["logs"].created_at = time.time() - 10 * 60 * 60
-    spool.rotate_for_export()
+    with caplog.at_level(logging.WARNING, logger="apitally.shared.spool"):
+        spool.rotate_for_export()
     assert [file.signal for file in spool.pending_files()] == ["logs"]
     for signal in ("traces", "metrics"):
         if files[signal].path is not None:
             assert not files[signal].path.exists()
+    # One data-loss warning per signal: the duplicate filter must not swallow a warning
+    # that differs only in its arguments
+    eviction_warnings = [record.getMessage() for record in caplog.records if "dropped" in record.message]
+    assert len(eviction_warnings) == 2
+    assert any("traces" in message for message in eviction_warnings)
+    assert any("metrics" in message for message in eviction_warnings)
 
 
 def test_size_cap_evicts_oldest_non_metrics_first(spool: Spool) -> None:

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -316,7 +316,7 @@ def test_init_without_write_token_exports_nothing(
     with TestClient(app) as client:
         assert client.get("/items/42").status_code == 200
     assert not activation.is_activated()
-    assert exporters.span == exporters.log == exporters.metric == []
+    assert exporters.span == exporters.log == []
 
 
 def test_init_disabled_skips_instrumentation(app: FastAPI):

--- a/uv.lock
+++ b/uv.lock
@@ -44,11 +44,12 @@ name = "apitally"
 source = { editable = "." }
 dependencies = [
     { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-http" },
+    { name = "opentelemetry-exporter-otlp-proto-common" },
     { name = "opentelemetry-instrumentation" },
     { name = "opentelemetry-instrumentation-logging" },
     { name = "opentelemetry-instrumentation-system-metrics" },
     { name = "opentelemetry-sdk" },
+    { name = "requests" },
 ]
 
 [package.optional-dependencies]
@@ -164,7 +165,7 @@ requires-dist = [
     { name = "inflection", marker = "extra == 'django-rest-framework'", specifier = ">=0.5.1" },
     { name = "litestar", marker = "extra == 'litestar'", specifier = ">=2.24.0" },
     { name = "opentelemetry-api", specifier = ">=1.43.0,<2.0.0" },
-    { name = "opentelemetry-exporter-otlp-proto-http", specifier = ">=1.43.0,<2.0.0" },
+    { name = "opentelemetry-exporter-otlp-proto-common", specifier = ">=1.43.0,<2.0.0" },
     { name = "opentelemetry-instrumentation", specifier = ">=0.64b0" },
     { name = "opentelemetry-instrumentation-asgi", marker = "extra == 'blacksheep'", specifier = ">=0.64b0" },
     { name = "opentelemetry-instrumentation-asgi", marker = "extra == 'litestar'", specifier = ">=0.64b0" },
@@ -177,6 +178,7 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.64b0" },
     { name = "opentelemetry-instrumentation-system-metrics", specifier = ">=0.64b0" },
     { name = "opentelemetry-sdk", specifier = ">=1.43.0,<2.0.0" },
+    { name = "requests", specifier = ">=2.26.0" },
     { name = "starlette", marker = "extra == 'fastapi'", specifier = ">=0.26.1,<2.0.0" },
     { name = "starlette", marker = "extra == 'starlette'", specifier = ">=0.26.1,<2.0.0" },
     { name = "uritemplate", marker = "extra == 'django-rest-framework'", specifier = ">=3.0.0" },
@@ -756,18 +758,6 @@ wheels = [
 ]
 
 [[package]]
-name = "googleapis-common-protos"
-version = "1.75.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "protobuf" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/b5/c8/f439cffde755cffa462bfbb156278fa6f9d09119719af9814b858fd4f81f/googleapis_common_protos-1.75.0.tar.gz", hash = "sha256:53a062ff3c32552fbd62c11fe23768b78e4ddf0494d5e5fd97d3f4689c75fbbd", size = 151035, upload-time = "2026-05-07T08:04:49.423Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/e7/c8/e2645aa8ed02fd4c7a2f59d68783b65b1f3cbdfe39a6308e156509d1fee8/googleapis_common_protos-1.75.0-py3-none-any.whl", hash = "sha256:961ed60399c457ceb0ee8f285a84c870aabc9c6a832b9d37bb281b5bebde43ed", size = 300631, upload-time = "2026-05-07T08:03:30.345Z" },
-]
-
-[[package]]
 name = "guardpost"
 version = "1.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1338,24 +1328,6 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/c1/e8098490ab15abf116dcaf9fa89ededcb35547c7d08d4b5a62f573dc1e63/opentelemetry_exporter_otlp_proto_common-1.43.0.tar.gz", hash = "sha256:c4e32ba6d6b13bdb2b8f6764c4fd28d00192826561aa04f6d14eedfce7ac076f", size = 20197, upload-time = "2026-06-24T15:20:00.247Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d0/b2/41ebc74ae1d5859901f1b69305de58724bf043381103d6ef413521cbc35a/opentelemetry_exporter_otlp_proto_common-1.43.0-py3-none-any.whl", hash = "sha256:123c3f9cc87218562490c63b36f497bf3a722faf174a515d1443f31ababa6264", size = 17048, upload-time = "2026-06-24T15:19:41.264Z" },
-]
-
-[[package]]
-name = "opentelemetry-exporter-otlp-proto-http"
-version = "1.43.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "googleapis-common-protos" },
-    { name = "opentelemetry-api" },
-    { name = "opentelemetry-exporter-otlp-proto-common" },
-    { name = "opentelemetry-proto" },
-    { name = "opentelemetry-sdk" },
-    { name = "requests" },
-    { name = "typing-extensions" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/fc/92/0b9f56412483a8891d4843890294796c9df8ab42417bd9bad8035d840cb3/opentelemetry_exporter_otlp_proto_http-1.43.0.tar.gz", hash = "sha256:fa8a42bb7d00ee5391f4c0b04d8e6a46c03caa437903296ab73a81dc11ba118f", size = 25406, upload-time = "2026-06-24T15:20:01.515Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b3/20/b685ed7af2e17c29ffc8af56f1fa8bc2033258fc30fb0d2b722f49d13ba0/opentelemetry_exporter_otlp_proto_http-1.43.0-py3-none-any.whl", hash = "sha256:647f603aa8efdbdb4dbff842e0729d0406a6fff26b295a72d3d60e7d963b2610", size = 21795, upload-time = "2026-06-24T15:19:43.164Z" },
 ]
 
 [[package]]

--- a/v1/export.md
+++ b/v1/export.md
@@ -1,0 +1,306 @@
+# feat: Disk-backed write-through spool for OTLP export (downtime resilience)
+
+Created: 2026-07-12. Updated for the post-#320 base and for the decision to retain the stock batch processors as the intake layer. Plan depth: Deep. Origin: grill session in this conversation (all decisions below were aligned with Simon or explicitly resolved during design).
+
+---
+
+## Context
+
+The v1 rewrite delegates OTLP export entirely to the stock OpenTelemetry batch processors and HTTP exporters. During an Apitally endpoint outage those absorb only ~10 seconds of failure per batch before dropping data. The 0.x SDK buffered aggregated sync payloads in memory for up to an hour and request logs in gzip temp files on disk (up to ~50MB), retrying every sync cycle. That resilience was repeatedly valuable in production and must be restored.
+
+The stock batch processors stay exactly where they are; what changes is what their exporters do and how bytes reach Apitally. The exporter delegate behind `ApitallySpanExporter` becomes a spool-writing exporter instead of the network exporter, turning the batch processors into a fast path to disk, and a single export worker thread sends spool files to the OTLP endpoint on a fixed interval:
+
+- Ended spans and log records leave RAM within ~1s: the retained batch processors (schedule delay lowered to 1s) drain them on their worker threads through the existing redaction exporter, and the new delegate serializes to protobuf and gzip-appends to temp files on disk. The in-memory queues become a short pass-through buffer; disk is the retry buffer.
+- The export worker rotates each signal's current spool file (0.x `rotate_file` pattern: close it, queue it for sending, start a new one) and sends the closed files every 15s (server-adjustable), streaming file bytes verbatim as the POST body. It also drives metric collection, so all three signals export in lockstep.
+- A failed send leaves the file queued for the next cycle. Outage handling is the same code path as normal operation, exercised every cycle, so it cannot rot.
+
+Base after PR #320: the keep/drop span processor stashes raw headers and bodies on exported SERVER span snapshots (`STASH_ATTRIBUTE` / `RequestStash` in `apitally/shared/span_processor.py`), and `ApitallySpanExporter` (`apitally/shared/exporter.py`) applies all redaction, mask callbacks, and body attribute injection on the export thread, wrapping a delegate `SpanExporter`. This plan reuses `ApitallySpanExporter` unchanged and swaps its delegate from the OTLP exporter to the spool-writing exporter. Two consequences: redaction runs before any bytes are written, so spool files only ever contain redacted data; and raw stashed bodies, which today sit in the batch processor's queue for up to 5s until export, leave RAM within ~1s.
+
+Backend investigation (apitally_cloud) confirmed feasibility: the OTLP ingest has no freshness validation and buckets all three signals by payload timestamps, so hour-late replay backfills correctly; the NATS JetStream dedup (content hash of the compressed body, 1h window) absorbs duplicate re-sends as long as replays are byte-identical and within 1 hour, which the design guarantees by capping each file's send eligibility at 59 minutes after its first send attempt (checked immediately before each POST, so the final retry's own transit and timeout still land inside the server's window) and sending stored bytes verbatim. Payload size is bounded on two layers: the receiver publishes the compressed body verbatim to NATS, whose production max_payload is 8MB (infrastructure helmfile; local docker-compose runs the 1 MiB NATS default), and the ingester silently drops payloads over 16 MiB decompressed.
+
+Secondary wins: client memory footprint shrinks (span/log queues hold data for ~1s instead of being the multi-second retry buffer, which post-#320 also means raw request/response bodies leave RAM faster), request volume to the cloud drops (~73 requests/min/process worst case today down to a few per cycle), and ClickHouse gets larger insert batches.
+
+Prior art (researched 2026-07-12): no reusable component exists. opentelemetry-python core and contrib have no disk-backed buffering or persistent export queue, and no open issue asking for one; the spec acknowledges the gap (opentelemetry-specification#3645, accepted but unsponsored and unimplemented). The Java contrib disk-buffering module and Swift PersistenceExporter exist but re-encode telemetry on replay, which alone disqualifies their pattern for the byte-identical dedup contract. The closest architectural cousins validate this design instead: .NET's experimental OTLP disk retry stores serialized request bytes and replays them verbatim, and pydantic/logfire privately built the same pattern (`logfire/_internal/exporters/otlp.py`, `DiskRetryer`: temp files holding final request bytes, daemon-thread replay, size cap) because nothing reusable existed. Generic durable-queue libraries (persist-queue, litequeue, diskcache) cannot append into a growing gzip stream or send a file verbatim, so they would add a dependency and SQLite fork hazards while all spool logic would still need to be written.
+
+---
+
+## Requirements
+
+- R1: Telemetry (spans, logs, metrics) survives Apitally OTLP endpoint downtime of at least 1 hour and is delivered after recovery, filed at original event time. Longer outages lose only files whose 59-minute retry window expired (roughly one file per outage hour, see R7); data never attempted survives within the size caps regardless of outage duration.
+- R2: SDK memory footprint must stay small and hard-bounded at all times; request/response detail must not accumulate in RAM (disk is the buffer).
+- R3: No duplicate serialization or compression anywhere: serialize protobuf once, gzip once (streaming to disk), send file bytes verbatim. Replay bytes must be identical across retries (server dedup relies on it).
+- R4: All three signals export together in the same cycle so the dashboard never shows metrics/logs/spans from inconsistent time windows.
+- R5: Export interval defaults to 15s, with an early first export after activation (startup event and first requests appear fast for new users), and the server can override the interval via the `Apitally-Export-Interval` response header.
+- R6: Writable filesystem is probed at activation; without one, the same spool machinery falls back to in-memory buffers with a small hard cap and a single warning.
+- R7: Retention: a file expires 59 minutes after its first send attempt, because any attempt might have published to NATS with the response lost, and re-sending the same bytes after the server's 1h dedup window would double-ingest; the horizon sits one minute under the window so the last permitted retry (checked immediately before each POST) still lands strictly inside it despite transit time and the 10s timeout. Never-attempted files carry no such risk and do not age out. Max spool size 50MB compressed on disk / 10MB in memory; oldest closed files evicted first; metrics files exempt from size eviction (only the retry-window expiry applies to them).
+- R8: Zero new user-facing config. Spool dir is the system temp dir (honors TMPDIR). Interval is controlled only by the default and the server header.
+- R9: Failure classification: connection errors, timeouts, 408, 429 and 5xx are retryable (file kept); other 4xx (including 402 quota and 401/403 auth) are permanent (file dropped). Warnings only for actual data loss, per SDK minimal-logging policy.
+- R10: Sent payloads must respect both backend size limits: the ingester's 16 MiB decompressed cap (silent drop) and the NATS max_payload of 8MB on the compressed body (publish failure, which the SDK would see as a retryable 503 and retry until age-out). Rotation at 4 MB uncompressed bytes written, enforced as a rotate-before-append fit check combined with bounded sub-batch encoding and capped per-record inputs (U2), keeps every closed file under the threshold even for incompressible content where gzip achieves no reduction. The caps: span bodies max 50 KB (capture layer plus the exporter's mask-callback re-check), span attribute values max 64 KB (SpanLimits; stash-injected header values are bounded in practice by web server header limits), and log record bodies and attribute values truncated to 2048 characters at encode time (U2, the server's log message contract), since nothing upstream bounds a log record body.
+- R11: Fork safety on par with current v1: parent quiesces and resumes with its spool intact; forked child starts with fresh spool state on its own activation.
+- R12: All redaction and body processing (the `ApitallySpanExporter` pass) happens before payload bytes are written to the spool; unredacted data never touches disk.
+
+---
+
+## Key Technical Decisions
+
+| Decision | Rationale |
+|---|---|
+| Retain the stock batch processors as the intake layer; only their exporter delegate changes, from network to spool | Inherits battle-tested queueing, wakeup-on-burst, drop accounting, force_flush/shutdown semantics, fork reinit, and instrumentation suppression instead of reimplementing them; `activation.py` wiring, fork choreography, and test fixtures stay nearly unchanged. Schedule delay set to 1s so telemetry reaches disk fast |
+| Write-through spool replaces the network exporters as the retry mechanism | Resilience path == normal path (always exercised); disk, not RAM, absorbs outages; 24x fewer requests; direct port of the proven 0.x request logger shape |
+| Reuse `ApitallySpanExporter` unchanged, delegate swapped to the spool-writing exporter | The #320 redaction wrapper already targets the standard `SpanExporter` interface with a delegate; pointing the delegate at the spool keeps all redaction/body logic and its contract tests intact, and satisfies R12 by construction |
+| Append serialized `Export*ServiceRequest` messages to one gzip stream per spool file | Protobuf concatenation of same-type messages merges repeated fields, so a closed file read verbatim is one valid OTLP request. Single gzip stream keeps the compression dictionary across micro-batches (better ratio than per-batch gzip) |
+| Send file bytes verbatim, retry the same bytes | Backend NATS dedup keys on a content hash of the compressed body with a 1h window; byte-identical replay within 1h makes delivery effectively exactly-once for the lost-response case. This is also why files are never merged or re-encoded for replay |
+| File expiry 59 minutes after first send attempt (re-checked immediately before each POST), uniform across signals; never-attempted files kept regardless of age | The expiry clock is anchored to the actual risk: an attempted file might have been published with the response lost, so re-sending after the 1h dedup window could double-ingest (0.x had the same window via client UUIDs as Nats-Msg-Id; verified in hub.py and messages.py, with no durable dedup layer behind it -- ClickHouse tables are plain MergeTree). The horizon sits one minute under the server window because the two clocks differ: the window opens when the first publish reaches NATS, the client clock starts at POST initiation, and the final retry's own transit and timeout must still land inside the window. A never-attempted file has provably never been published, so it can wait out any outage. During an outage only the probed oldest file has a running clock, so loss is bounded to roughly one file per outage hour and everything else delivers at recovery |
+| One export worker thread drives sending and metric collection | Calling the metric reader's collect() from the export cycle (instead of a periodic timer thread) makes signal lockstep structural (R4); the worker replaces the stock metric timer thread, so total thread count stays at three. Delta temporality makes collect-on-export correct at any cadence; the backend sums sub-minute deltas into the right minute bucket |
+| Flat 15s interval + `Apitally-Export-Interval` response header override + early first export | Replaces the 0.x two-interval hack. Server-side policy (new-app fast mode, live-dashboard fast mode) comes later without SDK releases; header parsing is trivial since we own the HTTP calls. "Export interval" is the stock OTel term (PeriodicExportingMetricReader's export_interval_millis) |
+| requests + opentelemetry-exporter-otlp-proto-common replace opentelemetry-exporter-otlp-proto-http | We only need the protobuf encoders (encode_spans/logs/metrics) and plain HTTP POSTs. Dropping proto-http removes dependence on its private retry internals entirely |
+| Memory fallback is the same spool with a different byte sink | One small backing class, not a second pipeline. Caps: 10MB, drop-oldest, warn once at activation |
+| Metrics exempt from size eviction | A full hour of metric payloads is a few hundred KB; exempting them structurally guarantees the aggregate data (the primary outage-survival value) survives the hour while span/log files churn under the 50MB cap |
+| Thundering-herd protection: rotate on demand, per-cycle send cap (~10 files), jittered sleeps between sends, +/-10% jitter on the export interval | Rotate-on-demand (rotate at the 4 MB threshold, or at export time only when the signal has no closed files waiting) means an outage produces few large files instead of one tiny file per cycle, shrinking the recovery burst by an order of magnitude; the cap spreads a full backlog over ~5+ cycles; interval jitter desynchronizes fleets whose processes started together in a deploy; 429-as-retryable remains the server-driven backstop. During an outage the SDK sends exactly one probe POST per cycle (oldest file first, cycle ends on first retryable failure), which is less traffic than healthy operation |
+
+Decisions resolved during design (recorded, not open): rotation threshold is 4 MB uncompressed, tracked as a single counter (worst-case compressed size then stays at ~4 MB, half the prod NATS max_payload, avoiding a poison file that could never be published and would retry until age-out; 4x margin under the ingester's 16 MiB decompressed cap; typical compressed size ~0.5 MB keeps POSTs fast on slow uplinks within the 10s timeout); at-least-once delivery accepted within the dedup window; non-retryable 4xx drops the file; orphaned spool files from crashed processes are best-effort cleaned up at activation (mtime older than 2h; live processes shield their files by touching them every export cycle); shutdown performs a final drain-and-send attempt with a short timeout (0.x parity); gzip compression is now always on (v1 currently exports uncompressed, so this is also a happy-path bandwidth win); startup event needs no special handling (it flows through the log pipeline into the spool and lands with the early first export); log record bodies and attribute values are truncated to 2048 characters at encode time (0.x parity and the server's log message contract; nothing upstream bounds a log body, and an unbounded record would break the 4 MB file bound, see R10/U2).
+
+### Practices carried over from the stock OTel implementation
+
+Reviewed the installed opentelemetry-python 1.43 sources. The split below follows the architecture: the shared `BatchProcessor` (`sdk/_shared_internal/__init__.py`) stays in the pipeline, so its practices come along automatically; the proto-http `OTLPSpanExporter` is removed (U6), so the practices worth keeping from it are implemented by hand in the export worker.
+
+Inherited for free by retaining the batch processors as intake: instrumentation suppression around the drain/redaction/spool-write path (`_SUPPRESS_INSTRUMENTATION_KEY`), queue-full drop warnings dampened by a `DuplicateFilter`, wakeup-on-burst when the queue crosses the batch threshold, `force_flush`/`shutdown` semantics with a timeout budget, and fork reinit via `os.register_at_fork` with a weakref.
+
+To implement by hand in the export worker, following the stock patterns:
+
+- Instrumentation suppression: hold `_SUPPRESS_INSTRUMENTATION_KEY` around metric collection, rotation, and HTTP sends, so our own POSTs (via requests) never generate spans that feed back into the pipeline (all instrumentations honor it via `is_instrumentation_enabled()`).
+- Rate-limited internal logging: a `DuplicateFilter`-style dampener on export-path loggers so a failing endpoint cannot log endlessly; this also bounds the feedback of our own warnings into the captured-logs pipeline.
+- Retry classification: stock treats 408 and all 5xx as retryable plus ConnectionError; the OTLP spec additionally lists 429 (stock Python omits it, arguably a gap). We follow the spec: connection errors, timeouts, 408, 429, 5xx retryable; everything else permanent.
+- Immediate single re-POST on ConnectionError: stock retries the POST once inline because servers may close idle keep-alive connections mid-request. With a 15s cycle this matters more for us (a stale-connection failure would otherwise delay a file a full cycle).
+- Shutdown discipline: a timeout budget (stock default 30s), a flag that makes further work no-ops, all sleeps as `Event.wait(...)` so shutdown wakes the worker immediately, join with the remaining budget.
+- Jitter to avoid fleet-wide synchronization: stock applies +/-20% to its retry backoff sleeps; our design has no backoff (a failed file simply waits for the next cycle), so the jitter lands on our two pacing sites instead -- the +/-10% on the export interval and the short sleeps between sends.
+- Named daemon thread (stock: `OtelBatchSpanRecordProcessor`); ours gets a clear `Apitally...` name for thread dumps.
+- Explicit User-Agent: stock sends `OTel-OTLP-Exporter-Python/<version>`; we send `apitally-py/<version>`.
+
+---
+
+## High-Level Technical Design
+
+Directional sketch, not implementation specification.
+
+```mermaid
+flowchart LR
+    subgraph request thread
+        A[ApitallySpanProcessor keep/drop + raw stash] --> B[stock BatchSpanProcessor queue]
+        C[ApitallyLogRecordProcessor] --> D[stock BatchLogRecordProcessor queue]
+    end
+    subgraph batch worker threads - 1s schedule
+        B -- drain --> R[ApitallySpanExporter redaction + bodies, unchanged]
+        R --> E[Spool exporter: encode_spans, append]
+        D -- drain --> F[Spool exporter: encode_logs, append]
+        E --> S[Spool: gzip append to current file per signal]
+        F --> S
+    end
+    subgraph export worker thread - every export interval
+        FF[force_flush batch processors] --> M[ApitallyMetricReader collect]
+        M -- encode_metrics --> S
+        S -- rotate --> Q[closed files queue, caps + eviction]
+        Q -- oldest first, paced --> P[POST file bytes verbatim, Content-Encoding gzip]
+        P -- 2xx --> DEL[delete file]
+        P -- conn error / 408 / 429 / 5xx --> KEEP[keep, end cycle, retry next cycle]
+        P -- other 4xx --> DROP[drop file, warn]
+        P -- Apitally-Export-Interval header --> I[interval override, clamped]
+    end
+```
+
+Spool file lifecycle: open (gzip writer over a byte sink) -> append serialized protobuf micro-batches -> rotate (close the gzip stream, queue the file for sending, start a new one; 0.x `rotate_file`) when 4 MB uncompressed has been written, or at export time if the signal has no closed files waiting -> send -> delete on 2xx or age/size eviction. In healthy operation the queue is empty every cycle, so rotation happens every 15s; during an outage the current file keeps growing toward the size threshold instead of producing one tiny file per cycle. The byte sink is a temp file (default) or an in-memory buffer (fallback); everything above the sink is identical. Appends come from the two batch worker threads and the export worker (metrics), so append/rotate is guarded by a small lock.
+
+Export cycle: force_flush both batch processors (so everything recorded before the cycle reaches the spool), collect metrics, rotate current files where due, send closed files oldest-first (capped per cycle, jittered sleeps between sends). Only the spool-writing exporters and the export worker are new code; the intake layer is the stock batch processors unchanged.
+
+Threads after this change: the two stock batch worker threads (retained) and the Apitally export worker, which replaces the stock metric reader timer thread. Three total, same as today.
+
+---
+
+## Implementation Units
+
+### U1. Spool storage: files, backings, caps, eviction
+
+**Goal:** A `Spool` that accepts serialized payload bytes per signal and manages file lifecycle (append, rotate, send-ordering, delete), the caps and eviction, the writable-filesystem probe, the memory fallback, and orphan cleanup. Thread-safe: appends come from the batch worker threads, rotation from the export worker.
+
+**Requirements:** R2, R3, R6, R7, R10.
+
+**Dependencies:** none.
+
+**Files:** `apitally/shared/spool.py` (new), `tests/shared/test_spool.py` (new).
+
+**Approach:** Spool file = gzip writer over a byte-sink backing (file backing: `tempfile.NamedTemporaryFile(prefix="apitally-", suffix=".gz", delete=False)` like 0.x `TempGzipFile`; memory backing: BytesIO). A lock guards append/rotate per signal. Track uncompressed bytes written per file; `append` rotates the current file first whenever the bytes already written plus the incoming payload would cross 4 MB (fit check, so no closed file ever exceeds the threshold; backend size limits, R10). The spool also rotates at export time, but only when the signal has no closed files waiting (rotate-on-demand: during a send backlog the current file keeps growing instead of adding one file per cycle). Closed files carry signal + creation time + compressed size + first-attempt timestamp (None until the export worker first POSTs the file). Eviction on every append/rotate: delete files whose first send attempt lies more than 59 minutes back (send horizon, R7); the export worker re-checks the same horizon immediately before each POST (U3); never-attempted files do not age out. While total compressed size exceeds the cap (50MB disk / 10MB memory), delete the oldest closed non-metrics file. Writable probe at construction (port 0.x `_check_writable_fs`); on failure, warn once and use memory backings. Write failures after activation (e.g. ENOSPC) get the simplest handling that avoids silent loss: an OSError during append or rotate discards the current file (its truncated gzip stream is unsalvageable and would otherwise be 2xx'd by the receiver and dropped at decompression), warning once per episode via the rate-limited logger; the next append opens a fresh file. An OSError while reading a file for a send drops that file the same way, so an unreadable file cannot block the queue. Best-effort deletion of `apitally-*.gz` files in the spool dir with mtime older than 2h at construction. Live processes protect their files from sibling sweeps through a liveness touch: the export worker `os.utime`s every spool file it holds once per cycle (U3), so the 2h threshold only catches files whose owner stopped cycling (crashed or stalled processes whose files would never be sent anyway). The spool retains open file objects for sending (0.x `TempGzipFile` pattern), so even a mis-timed sweep by a sibling cannot break an in-flight send. Constants module-level, no config. The spool never deletes files from a finalizer (no `__del__`-based cleanup): only explicit eviction, a successful send, and the test-only teardown delete files. This rule is what makes it safe for a forked child to abandon an inherited spool object (U5).
+
+**Patterns to follow:** 0.x `TempGzipFile`, `RequestLogger.rotate_file`, and `RequestLogger.maintain` in `git show main:apitally/client/request_logging.py`; module/comment conventions of `apitally/shared/`.
+
+**Test scenarios:**
+- Appending two serialized `ExportTraceServiceRequest` payloads to a spool file, rotating, gunzipping and parsing yields one merged request containing both payloads' resource_spans (proves R3's concatenation property end to end).
+- Closed file bytes are stable: reading the file twice returns identical bytes.
+- An append that would push uncompressed written bytes past the 4 MB threshold rotates first and lands in a fresh file, so no closed file's decompressed size exceeds the threshold.
+- Export-time rotation only happens when the signal has no closed files waiting; with a backlog present, appends keep going to the current file.
+- A file whose first send attempt lies more than 59 minutes back is deleted on the next maintenance pass, including metrics files; a never-attempted file of any age survives.
+- When total size exceeds the cap, oldest non-metrics files are deleted first and metrics files survive.
+- Memory backing passes the same append/rotate/read/evict scenarios (parametrize backings where practical).
+- Failed writability probe falls back to memory backing and logs exactly one warning.
+- An append that raises OSError discards the current file with a single warning; the next append starts a fresh file.
+- Orphan cleanup deletes a stale `apitally-*.gz` file older than 2h and leaves a fresh one alone.
+- The liveness touch refreshes mtimes: after touching, a sweep with the 2h threshold leaves the files in place.
+
+**Verification:** `uv run pytest tests/shared/test_spool.py` green; a closed file gunzips with the `gzip` CLI as a sanity check.
+
+### U2. Spool-writing exporters behind the retained batch processors
+
+**Goal:** A spool-writing exporter that encodes batches (`encode_spans` / `encode_logs` from opentelemetry-exporter-otlp-proto-common) and appends to the spool, satisfying the `SpanExporter` and `LogRecordExporter` interfaces (one generic implementation parameterized by encoder and signal; how the two interfaces are satisfied is implementer's call). The stock `BatchSpanProcessor` / `BatchLogRecordProcessor` are retained as intake with all four constructor parameters passed explicitly (`schedule_delay_millis=1000`, the other three at their stock defaults), because the stock constructors fall back to `OTEL_BSP_*` / `OTEL_BLRP_*` env vars for any parameter left as None, and this private pipeline must not be tuned by env vars aimed at the user's own exporters (same pattern and rationale as `setup_tracer_provider` in `apitally/shared/providers.py`); spans drain through the existing `ApitallySpanExporter` wrapping the spool exporter, so all redaction and body processing happens on the batch worker thread before bytes reach the spool (R12), exactly as the export call works today.
+
+**Requirements:** R2, R3, R12.
+
+**Dependencies:** U1.
+
+**Files:** `apitally/shared/export.py` (new, spool exporters + export worker live together), `tests/shared/test_export.py` (new).
+
+**Approach:** The exporter encodes and appends in bounded sub-batches: `export(batch)` splits the drained batch into chunks of at most 32 spans or log records, encodes each chunk via proto-common, and calls `spool.append(signal, bytes)` per chunk (protobuf concatenation makes several small requests in one file exactly as valid as one big one). Log records are truncated before encoding: body strings and attribute values longer than a 2048-character module constant are cut, the direct port of 0.x `MAX_LOG_MSG_LENGTH` and the server's log message contract (the backend validates messages at max_length=2048, so longer bodies are dead bytes on the wire). This closes the one unbounded per-record input: the OTel `LoggingHandler` sets body = `record.getMessage()` verbatim and `LoggerProvider` accepts no limits, so a single `logger.info(huge_string)` would otherwise produce an unsplittable oversized chunk whose file could never publish (NATS max_payload) and would poison-retry until age-out. With every per-record input capped (span bodies 50 KB, span attribute values 64 KB, log bodies and attribute values 2048 characters), a worst-case 32-record chunk stays well under 4 MB, so together with the spool's rotate-before-append fit check (U1) every closed file stays under the threshold regardless of batch processor tuning. The sub-batch size and truncation cap are module constants like the other caps. `force_flush` returns True (nothing buffered); `shutdown` is a no-op toward the spool (lifecycle owned by activation). The downstream-swap contract in `apitally/shared/activation.py` (`span_processor.downstream = ...`) is untouched because the downstream is still a stock batch processor; existing tests keep substituting in-memory downstreams. Queue overflow, drop warnings, suppression, and fork reinit are stock batch processor behavior, not ours to reimplement.
+
+**Patterns to follow:** `ApitallySpanExporter` delegate wiring in `apitally/shared/exporter.py` and `create_batch_span_processor` in `apitally/shared/activation.py`.
+
+**Test scenarios:**
+- A span batch exported through `ApitallySpanExporter(spool exporter)` appears in the spool as a parseable encoded payload with the expected span names and resource.
+- A span carrying a stashed raw body and sensitive headers ends up in the spool redacted: the gunzipped payload contains the masked values and never the raw secret bytes (R12).
+- A log batch exported through the spool exporter appears in the spool as a parseable encoded payload.
+- A batch larger than the sub-batch size is appended as multiple payloads; the gunzipped file parses to the full span set with none lost or duplicated.
+- A log record with a body larger than the truncation cap lands in the spool with the body cut to the cap; the encoded payload parses and the record's other fields are intact.
+
+**Verification:** `uv run pytest tests/shared/test_export.py` green; `tests/shared/test_exporter.py` (the #320 redaction contract tests) stays green untouched.
+
+### U3. Export worker: cycle, HTTP, retry, interval override
+
+**Goal:** The background thread that runs every export interval: force_flush the batch processors, collect metrics, rotate current spool files, send closed files oldest-first; handles failures per R9 and the interval header per R5.
+
+**Requirements:** R1, R3, R4, R5, R9.
+
+**Dependencies:** U1, U2, U4 (metric collection hook).
+
+**Files:** `apitally/shared/export.py`, `tests/shared/test_export.py`.
+
+**Approach:** Port the 0.x `client_threading.ApitallyClient` loop shape (daemon thread with a clear name, stop Event interrupting all sleeps, atexit-registered shutdown with a timeout budget and final drain-and-send). The worker stores no references to the batch processors or the metric reader; each cycle resolves them through the stable identities (`span_processor.downstream`, `log_processor.downstream`, `metrics.reader`), which the fork handlers repoint to fresh instances (U5) -- construction-time references would silently target shut-down processors and the detached old reader after the first fork. Export cycle, with the suppress-instrumentation context key held throughout: force_flush the span and log batch processors, call the metric reader's `collect()`, rotate current spool files where due (rotate-on-demand rule, U1), touch all held spool files as a liveness marker (orphan-sweep protection, U1), then POST closed files oldest-first with a per-cycle cap (~10) and short jittered sleeps between sends (0.x pacing). Immediately before each POST the worker re-checks the send horizon and evicts instead of sending when the file's first attempt lies more than 59 minutes back, so the last permitted retry lands strictly inside the server's 1h dedup window regardless of queue wait, transit, or timeout. The wait between cycles carries +/-10% jitter so fleets whose processes started together in a deploy drift apart instead of bursting in phase. POST via a `requests.Session`: URL from config `otlp_endpoint` + `/v1/{traces,logs,metrics}`, headers Authorization Bearer + `Apitally-Env` (reuse `providers.export_headers` / `providers.endpoint_url`, relocated or imported), `Content-Type: application/x-protobuf`, `Content-Encoding: gzip`, `User-Agent: apitally-py/<version>`, body streamed from the file, timeout 10s, one immediate re-POST on ConnectionError (stale keep-alive race, stock pattern). Each POST stamps the file's first-attempt timestamp if not yet set, starting its 59-minute send horizon (R7). On 2xx delete the file; on connection error/timeout/408/429/5xx keep it and end the cycle; on other 4xx drop it (warn, rate-limited to once per status per process, since this is data loss). Read `Apitally-Export-Interval` (integer seconds) from any response, clamp to [5, 900]. First export fires ~2s after thread start (R5), then every interval. Logging policy per R9 with duplicate-filter rate limiting: buffering due to outage is debug; eviction/age-out and permanent-status drops warn once per episode.
+
+**Test scenarios:** (use a local stub HTTP server or requests mocking; stub preferred since streaming and headers matter)
+- One export cycle produces POSTs for all three signals from the same cycle (R4 lockstep), with correct per-signal URLs, auth/env headers, User-Agent, and gzip content-encoding.
+- Successful export deletes the files; spool is empty afterwards.
+- On 503 the file is kept and re-sent next cycle with byte-identical body (capture and compare both request bodies; proves R3/dedup contract).
+- Connection refused behaves like 503 (kept, retried), and the cycle ends without attempting remaining files.
+- Repeated failing cycles do not accumulate one file per cycle: data recorded during the outage keeps appending to the current file (rotate-on-demand), and the send attempts across those cycles are one probe per cycle.
+- A file kept across failing cycles is evicted once 59 minutes have passed since its first attempt (warned as data loss); a never-attempted file outlives that horizon and delivers at recovery.
+- A file still inside the horizon at cycle start but past it by the time its POST would fire is evicted at the send site, not sent (pins the POST-time horizon check).
+- 402 response drops the traces file, warns once, and does not affect logs/metrics files.
+- `Apitally-Export-Interval: 5` response header shortens the next cycle; an out-of-range value is clamped.
+- First export happens within a few seconds of start and includes the startup event log record.
+- No spans are generated for the export POSTs when requests instrumentation is active (suppression key).
+- Shutdown flushes the batch processors, rotates, attempts one final send, and stops the thread.
+
+**Verification:** `uv run pytest tests/shared/test_export.py` green; thread count before/after activation is unchanged versus today (three).
+
+### U4. Metrics reader rework: collect-on-export
+
+**Goal:** `ApitallyMetricReader` becomes a non-periodic `MetricReader` (no timer thread) whose `_receive_metrics` encodes via `encode_metrics` and appends to the spool; the export worker calls `collect()` each cycle.
+
+**Requirements:** R2, R4.
+
+**Dependencies:** U1.
+
+**Files:** `apitally/shared/metrics.py`, `tests/shared/test_metrics.py`.
+
+**Approach:** Subclass `MetricReader` directly, passing the existing `HISTOGRAM_PREFERRED_TEMPORALITY` / `HISTOGRAM_PREFERRED_AGGREGATION` through the constructor. Keep the existing guards that motivated the current subclass (safe collect after detach, atexit shutdown, `detached_readers` fork workaround) only where they still apply without a timer thread; delete what the removal of the periodic thread makes unnecessary. `attach_reader`/`detach_reader` signatures stay so `activation.py` changes stay mechanical.
+
+**Test scenarios:**
+- `collect()` invoked twice produces two delta payloads in the spool whose histogram values sum to the recorded totals (delta correctness across collects).
+- No timer thread exists after attach (assert on threading enumeration).
+- Detach then collect is a no-op without warnings (preserves the current guard's behavior).
+
+**Verification:** `uv run pytest tests/shared/test_metrics.py` green.
+
+### U5. Wiring: activation, providers, fork handling, conftest
+
+**Goal:** `start_pipelines` builds the spool and export worker and swaps the batch processors' exporter delegates; fork handlers additionally quiesce/restart the export worker; test fixtures repointed.
+
+**Requirements:** R1, R8, R11, R12.
+
+**Dependencies:** U1, U2, U3, U4.
+
+**Files:** `apitally/shared/activation.py`, `apitally/shared/providers.py`, `tests/conftest.py`, `tests/shared/test_activation.py`, `tests/shared/test_providers.py`.
+
+**Approach:** The batch processor wiring keeps its current shape: `create_batch_span_processor` builds `BatchSpanProcessor(ApitallySpanExporter(<spool exporter>))` with all constructor parameters passed explicitly (U2), and the log pipeline builds `BatchLogRecordProcessor(<spool exporter>)` likewise; the keep/drop wrappers, downstream-swap contract, `retired_processors`, and `inherited_span_processor` choreography are all unchanged. `providers.py` drops `create_span_exporter`/`create_metric_exporter`/`create_log_exporter` (replaced by a spool exporter factory seam); `endpoint_url`/`export_headers` move to (or are imported by) the export worker. `start_pipelines` additionally constructs one `Spool` and one export worker. `before_fork` additionally stops the worker thread, then rotates (closes) each signal's current spool file: the batch processors are already shut down at that point, which drains their queues to the spool, so after rotation zero open gzip writers exist at the instant of fork and the child cannot corrupt parent files through inherited shared file descriptors. `after_fork_in_parent` restarts the thread (same spool, closed files intact; the next append opens a fresh current file); no re-wiring is needed because the worker never stores processor or reader references -- each cycle resolves `span_processor.downstream`, `log_processor.downstream`, and `metrics.reader` from module state (U3), which this handler has already repointed to the fresh instances. `after_fork_in_child` abandons the inherited spool reference without flushing, closing, or unlinking anything, and resets so the child's activation builds fresh spool state (its own files); combined with the spool's no-finalizer-deletion rule (U1), dropping the inherited object can never touch the parent's files. `reset()` tears everything down for tests. Conftest: the `exporters` fixture currently monkeypatches the `providers.create_*_exporter` factories; repoint it at the new factory seam so activation tests get in-memory downstreams without network or disk, keeping the fixture's shape.
+
+**Patterns to follow:** existing fork choreography in `apitally/shared/activation.py` (`retired_processors`, `inherited_span_processor`, weakref at-fork registration); existing conftest fixture shape.
+
+**Test scenarios:**
+- Activation with a user-provided tracer provider and with Apitally's own provider both produce a working spool pipeline (mirror existing activation tests).
+- Fork-in-parent: export worker thread restarts, pre-fork closed files still get sent afterwards, and metrics recorded after the fork are exported (a post-fork metrics POST proves the worker resolves the fresh reader, not the detached one).
+- Fork-in-child then child activation: fresh spool, no access to parent files, exactly one export worker thread in the child.
+- Fork with a non-empty current spool file: the child drops its inherited references and a GC runs; the parent's spool files are byte-identical afterwards and still gunzip cleanly.
+- `reset()` leaves no running export worker thread and no leaked temp files.
+
+**Verification:** full suite `uv run pytest` green, including all framework adapter tests and the #320 exporter contract tests unchanged in behavior.
+
+### U6. Dependencies and migration notes
+
+**Goal:** Swap `opentelemetry-exporter-otlp-proto-http` for `opentelemetry-exporter-otlp-proto-common` + `requests` in `pyproject.toml`; document the behavior change.
+
+**Requirements:** R8 (no new config to document), supports R3.
+
+**Dependencies:** U5 (last import of proto-http gone).
+
+**Files:** `pyproject.toml`, `MIGRATION.md`.
+
+**Approach:** Verify nothing else imports proto-http (contrib instrumentations do not). Add a short MIGRATION.md section: telemetry is spooled to the system temp dir and exported every ~15s; survives endpoint downtime up to 1h / 50MB; read-only filesystems fall back to a small in-memory buffer; TMPDIR relocates the spool; spool files only ever contain redacted data.
+
+**Test scenarios:** Test expectation: none -- dependency and docs change; U5's suite run covers the import swap.
+
+**Verification:** `uv run pytest` green after `uv sync`; `grep -r otlp.proto.http apitally/` returns nothing.
+
+### U7. End-to-end integration test
+
+**Goal:** One test that exercises the whole pipeline against a real local HTTP server: adapter request -> spool files on disk -> exported -> decoded server-side.
+
+**Requirements:** R1, R3, R4, R5, R12.
+
+**Dependencies:** U5.
+
+**Files:** `tests/shared/test_export.py`.
+
+**Approach:** Stdlib `http.server` on a random port recording bodies/headers, `otlp_endpoint` pointed at it. Drive a request through one adapter (Starlette or Flask; remember WSGI tests must consume the response iterable), force an export cycle, decode the received protobuf.
+
+**Test scenarios:**
+- A handled request produces trace + log + metric POSTs whose decoded contents carry the expected route, status, and startup event.
+- With body capture enabled and a request containing a sensitive field, the received payload carries the redacted body attribute and the raw secret appears nowhere on disk or on the wire (R12).
+- Server down for the first cycles then up: everything recorded during downtime arrives after recovery with original timestamps, byte-identical to the first send attempts.
+
+**Verification:** `uv run pytest` green; optionally a manual smoke run of an example app against staging.
+
+---
+
+## Scope Boundaries
+
+### Deferred to Follow-Up Work
+
+- Backend: implement `Apitally-Export-Interval` response header policy (e.g. fast interval for newly created apps, later live-dashboard fast mode). Client honors the header from day one; absent header means the 15s default.
+- Backend: local docker-compose NATS runs the 1 MiB default max_payload while production runs 8MB; align dev with prod (add the flag in `docker-compose.yaml`) so a >1 MiB compressed payload does not fail only in dev.
+- Backend: the OTLP logs ingester's `_render_log_body` (`ingester/otlp_logs.py`) does not enforce the 2048-character log message limit that the legacy ingest path validates (`messages.py`).
+
+### Out of scope
+
+- Spool persistence across process restarts (0.x never had it; orphan files are cleaned up, not reclaimed).
+- User-facing configuration for spool location, caps, or interval (deliberate, R8).
+- gRPC OTLP transport.
+
+---
+
+## Risks
+
+- The send loop is custom code replacing the stock exporters' retry logic. Mitigated by porting the proven 0.x loop shape, carrying over the stock robustness practices (see Key Technical Decisions), and by U7's end-to-end coverage; the intake layer is the stock batch processors unchanged, so the blast radius is the export worker and spool only.
+- Thread lifecycle across fork is historically fiddly. Mitigated by reusing the existing quiesce/swap choreography in `activation.py` (batch processor handling is already exercised by the current suite) and testing both fork directions (U5).
+- Windows temp-file semantics (reopening a `delete=False` NamedTemporaryFile) follow the 0.x pattern that already shipped cross-platform; keep the same open/close discipline.
+
+## Verification (overall)
+
+1. `uv run pytest` fully green.
+2. Manual smoke: example app with `APITALLY_OTLP_ENDPOINT` pointed at a local stub; kill the stub for several minutes under traffic, restart it, confirm all data arrives and files are cleaned up; watch process RSS stay flat throughout.
+3. Optional staging run against the real endpoint to confirm dashboard latency (~15s) and startup-event freshness.


### PR DESCRIPTION
## What

Replaces the stock OTel exporters' in-memory delivery path with a disk-backed write-through spool, restoring the 0.x behavior where telemetry survives Apitally hub outages of up to an hour. The full design is retained in `v1/export.md`.

- **Spool storage** (`apitally/shared/spool.py`): per-signal gzip files in the temp dir (in-memory fallback if unwritable), rotated at 4 MB uncompressed, capped at 50 MB on disk / 10 MB in memory with oldest-first eviction (metrics exempt), orphan cleanup for files left by crashed processes.
- **Spool-writing exporters** (`apitally/shared/export.py`): the retained batch processors drain into exporters that encode to OTLP protobuf and append to the spool; log values are truncated at 2 KB.
- **Export worker**: a single background thread flushes processors, collects metrics, rotates the spool and streams pending files verbatim to the OTLP endpoint every interval (default 15s, server-adjustable via `Apitally-Export-Interval` header, jittered +/-10%). The disk is the retry buffer: failed files wait for the next cycle, no backoff, expiry 59 minutes after the first attempt so replays stay inside the server's dedup window.
- **Metrics reader rework** (`apitally/shared/metrics.py`): non-periodic reader driven by the export worker, so traces, logs and metrics export in lockstep without a separate timer thread.
- **Wiring** (`apitally/shared/activation.py`): spool and worker lifecycle in activation, including fork handling (parent restarts the worker, child re-activates with a fresh spool).
- **Dependencies**: `opentelemetry-exporter-otlp-proto-http` swapped for `opentelemetry-exporter-otlp-proto-common` plus `requests`.

## Why

The v1 rewrite initially sent telemetry straight from the batch processors, so any hub outage lost data. This restores outage resilience with bounded local buffering and byte-identical replay (unchanged file bytes per attempt) so the server can dedupe retries by content hash.

## Reviewer notes

- Send failures log at debug; warnings fire only when data is actually dropped (expiry, size cap, disk errors, 4xx rejection once per status).
- `send_file` streams the file handle directly with `seek(0)` before each attempt; `requests.ConnectionError`/`Timeout` are matched before `OSError`, which they subclass.
- Coverage: unit tests per module plus end-to-end integration tests through the Starlette adapter against a stub OTLP server (261 passed, 3 Linux-only skipped).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a disk-backed, write-through export spool with a background worker so telemetry survives Apitally hub outages (up to 1 hour) with bounded local buffering. Restores 0.x resilience while keeping batch processors as the intake layer.

- **New Features**
  - Spool storage: per-signal gzip files in the system temp dir; rotate at 4 MB; 50 MB on-disk cap (10 MB in-memory fallback); flush on close; cleans up orphans.
  - Exporters: encode OTLP protobuf and append to the spool; truncate log values at 2 KB.
  - Export worker: single thread flushes processors, collects metrics, rotates the spool, and streams files every ~15s (server can override via `Apitally-Export-Interval`; ±10% jitter); paced drain with a per-cycle send cap and fast stop; streams file bodies with `seek(0)` per retry; retries via disk with 59-minute expiry; logs retries at debug and warns only when data is dropped.
  - Metrics reader: non-periodic and driven by the export worker so traces, logs, and metrics export in lockstep.
  - Activation: wires spool and worker lifecycle, including fork handling (parent restarts worker; child re-activates with a fresh spool).

- **Dependencies**
  - Replaces `opentelemetry-exporter-otlp-proto-http` with `opentelemetry-exporter-otlp-proto-common` and `requests`.

<sup>Written for commit 9404b804a64b81bcc54a398e613d0cf03fbcdf00. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/apitally/apitally-py/pull/321?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

