### PR TITLE
Restore detailed error reporting

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -65,7 +65,6 @@ All options move to keyword arguments of `apitally.init(...)` (or `ApitallyPlugi
 | `exclude_paths` | `exclude_paths` (unchanged) |
 | `exclude_callback` | Removed. Replaced by the sampling API: `sample_rate`, `sample_on_request` / `sample_on_response` (see below). |
 | `apitally.client.*` imports | Removed. The Hub transport is replaced by OTLP export; there is no public API under `apitally.client`. |
-| Validation and server error capture | No SDK-side API anymore. Apitally derives these server-side from standard OpenTelemetry exception events on traces. |
 
 ## Consumers
 

--- a/apitally/django.py
+++ b/apitally/django.py
@@ -20,7 +20,7 @@ from django.utils.functional import Promise
 from django.views.generic.base import View
 from opentelemetry.instrumentation.django import DjangoInstrumentor
 
-from apitally.shared import activation, config, metrics, startup
+from apitally.shared import activation, config, metrics, server_errors, startup, validation_errors
 from apitally.shared.config import (
     BODY_TOO_LARGE,
     MAX_BODY_SIZE,
@@ -130,21 +130,28 @@ class ApitallyDjangoMiddleware:
         start_time = time.perf_counter()
         request_size: int | None = None
         request_body: bytes | None = None
+        init_consumer()
+        exception_holder = server_errors.init_exception_holder()
         try:
-            init_consumer()
-            request_size = parse_content_length(request.headers.get("Content-Length"))
-            request_body = self.capture_request_body(request, config, request_size)
-        except Exception:  # pragma: no cover
-            logger.exception("Error in Apitally Django middleware")
-        response = self.get_response(request)
-        try:
-            self.finalize(request, response, config, start_time, request_size, request_body)
-        except Exception:  # pragma: no cover
-            logger.exception("Error in Apitally Django middleware")
+            try:
+                request_size = parse_content_length(request.headers.get("Content-Length"))
+                request_body = self.capture_request_body(request, config, request_size)
+            except Exception:  # pragma: no cover
+                logger.exception("Error in Apitally Django middleware")
+            response = self.get_response(request)
+            try:
+                self.finalize(request, response, config, start_time, request_size, request_body, exception_holder)
+            except Exception:  # pragma: no cover
+                logger.exception("Error in Apitally Django middleware")
+            return response
         finally:
-            # finalize_streaming has already snapshotted the consumer for streaming responses
+            # finalize_streaming retains the holder and consumer after this request context is reset
             reset_consumer()
-        return response
+            server_errors.reset_exception_holder()
+
+    def process_exception(self, request: HttpRequest, exception: Exception) -> None:
+        server_errors.set_exception(exception)
+        return None
 
     def capture_request_body(
         self, request: HttpRequest, config: ApitallyConfig, request_size: int | None
@@ -180,12 +187,14 @@ class ApitallyDjangoMiddleware:
         start_time: float,
         request_size: int | None,
         request_body: bytes | None,
+        exception_holder: server_errors.ExceptionHolder,
     ) -> None:
         streaming = getattr(response, "streaming", False)
         response_size = parse_content_length(response.get("Content-Length"))
         if response_size is None and not streaming:
             response_size = len(response.content)
         route = self.get_route(request)
+        consumer = get_consumer_identifier()
         if client_address := request.META.get("REMOTE_ADDR"):
             set_request_attribute("client.address", client_address)
         span = get_server_span()
@@ -220,13 +229,31 @@ class ApitallyDjangoMiddleware:
                 response_size,
                 route,
                 span,
+                exception_holder,
             )
             return
+        method = request.method or ""
+        if (
+            response.status_code == 422
+            and route
+            and method.upper() != "OPTIONS"
+            and validation_errors.is_json_content_type(response.get("Content-Type"))
+        ):
+            data = validation_errors.decode_json_response(response.content, response.get("Content-Encoding"))
+            if data is not None:
+                validation_errors.add_validation_errors(
+                    consumer,
+                    method,
+                    route,
+                    validation_errors.extract_pydantic_validation_errors(data),
+                )
+        if response.status_code == 500:
+            server_errors.add_server_error(consumer, method, route, exception_holder)
         metrics.record_request(
-            method=request.method or "",
+            method=method,
             route=route or "",
             status_code=response.status_code,
-            consumer=get_consumer_identifier(),
+            consumer=consumer,
             duration=time.perf_counter() - start_time,
             request_size=request_size,
             response_size=response_size,
@@ -243,6 +270,7 @@ class ApitallyDjangoMiddleware:
         response_size: int | None,
         route: str | None,
         span: Span | None,
+        exception_holder: server_errors.ExceptionHolder,
     ) -> None:
         """Defer the span export and record metrics once the streamed content completes,
         after the OTel middleware has ended the SERVER span."""
@@ -277,6 +305,8 @@ class ApitallyDjangoMiddleware:
                     processor.update_stash(span_id, response_body=bytes(body))
                 if processor is not None and span_id is not None:
                     processor.finish_export(span_id, extra or None)
+                if status_code == 500:
+                    server_errors.add_server_error(consumer, method, route, exception_holder)
                 metrics.record_request(
                     method=method,
                     route=route or "",
@@ -297,6 +327,7 @@ class ApitallyDjangoMiddleware:
                 bytes_sent = 0
                 body: bytearray | bytes | None = bytearray() if capture_body else None
                 completed = False
+                holder_token = server_errors.exception_holder_var.set(exception_holder)
                 try:
                     async for chunk in async_content:
                         bytes_sent += len(chunk)
@@ -306,8 +337,14 @@ class ApitallyDjangoMiddleware:
                                 body = BODY_TOO_LARGE
                         yield chunk
                     completed = True
+                except Exception as exc:
+                    server_errors.set_exception(exc, exception_holder)
+                    raise
                 finally:
                     finish(bytes_sent, body, completed)
+                    # A failed stream retains the holder for an event ID from outer Sentry middleware.
+                    if completed or exception_holder.server_error_key is None:
+                        server_errors.exception_holder_var.reset(holder_token)
 
             response.streaming_content = async_stream_wrapper()
         else:
@@ -317,6 +354,7 @@ class ApitallyDjangoMiddleware:
                 bytes_sent = 0
                 body: bytearray | bytes | None = bytearray() if capture_body else None
                 completed = False
+                holder_token = server_errors.exception_holder_var.set(exception_holder)
                 try:
                     for chunk in content:
                         bytes_sent += len(chunk)
@@ -326,8 +364,14 @@ class ApitallyDjangoMiddleware:
                                 body = BODY_TOO_LARGE
                         yield chunk
                     completed = True
+                except Exception as exc:
+                    server_errors.set_exception(exc, exception_holder)
+                    raise
                 finally:
                     finish(bytes_sent, body, completed)
+                    # A failed stream retains the holder for an event ID from outer Sentry middleware.
+                    if completed or exception_holder.server_error_key is None:
+                        server_errors.exception_holder_var.reset(holder_token)
 
             response.streaming_content = stream_wrapper()
 

--- a/apitally/fastapi.py
+++ b/apitally/fastapi.py
@@ -6,15 +6,18 @@ from collections.abc import Iterator
 from typing import TYPE_CHECKING, Any
 
 from fastapi import FastAPI
+from opentelemetry.instrumentation.asgi import OpenTelemetryMiddleware
 from opentelemetry.instrumentation.fastapi import FastAPIInstrumentor
+from starlette.middleware.errors import ServerErrorMiddleware
+from starlette.routing import Match
 
-from apitally.shared import activation, config, startup
+from apitally.shared import activation, config, server_errors, startup, validation_errors
 from apitally.shared.asgi import ApitallyASGIMiddleware
 
 
 if TYPE_CHECKING:
     from starlette.routing import BaseRoute
-    from starlette.types import Scope
+    from starlette.types import ASGIApp, Receive, Scope, Send
 
 
 __all__ = ["init"]
@@ -63,15 +66,41 @@ def _instrument_app(app: FastAPI) -> None:
     build_inner = app.build_middleware_stack
 
     def build_with_shim() -> activation.ASGIActivationShim:
+        inner = build_inner()
+        if (
+            isinstance(inner, ServerErrorMiddleware)
+            and isinstance(inner.app, OpenTelemetryMiddleware)
+            and isinstance(inner.app.app, ServerErrorMiddleware)
+        ):
+            inner.app.app.app = _ExceptionRecordingMiddleware(inner.app.app.app)
         return activation.ASGIActivationShim(
             ApitallyASGIMiddleware(
-                build_inner(),  # ty: ignore[invalid-argument-type]
+                inner,  # ty: ignore[invalid-argument-type]
                 resolve_route=_resolve_route,
                 use_scope_client_address=True,
+                validation_error_extractor=_extract_validation_errors,
             )
         )
 
     app.build_middleware_stack = build_with_shim  # ty: ignore[invalid-assignment]
+
+
+class _ExceptionRecordingMiddleware:
+    def __init__(self, app: ASGIApp) -> None:
+        self.app = app
+
+    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
+        try:
+            await self.app(scope, receive, send)
+        except Exception as exc:
+            server_errors.set_exception(exc)
+            raise
+
+
+def _extract_validation_errors(status_code: int, data: object) -> list[validation_errors.ValidationError]:
+    if status_code != 422:
+        return []
+    return validation_errors.extract_pydantic_validation_errors(data)
 
 
 def _resolve_route(scope: Scope) -> str | None:
@@ -79,7 +108,28 @@ def _resolve_route(scope: Scope) -> str | None:
     # templated path is only on the effective route context, scope["route"].path lacks the prefix
     context = scope.get("fastapi", {}).get("effective_route_context")
     path = getattr(context, "path", None) or getattr(scope.get("route"), "path", None)
-    return path if isinstance(path, str) else None
+    if isinstance(path, str):
+        return path
+
+    routes = getattr(scope.get("app"), "routes", None)
+    return _resolve_registered_route(scope, routes) if isinstance(routes, list) else None
+
+
+def _resolve_registered_route(scope: Scope, routes: list[BaseRoute]) -> str | None:
+    for registered_route in routes:
+        contexts = getattr(registered_route, "effective_route_contexts", None)
+        routes_to_match = contexts() if callable(contexts) else [registered_route]
+        for route in routes_to_match:
+            match, child_scope = route.matches(scope)
+            if match != Match.FULL:
+                continue
+            if (child_routes := getattr(route, "routes", None)) is not None:
+                path = _resolve_registered_route({**scope, **child_scope}, child_routes)
+                return getattr(route, "path", "") + path if path else None
+            path = getattr(route, "path", None)
+            if isinstance(path, str):
+                return path
+    return None
 
 
 def _get_paths(app: FastAPI) -> list[dict[str, str]]:

--- a/apitally/flask.py
+++ b/apitally/flask.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING, Any
 from flask import Flask, request
 from opentelemetry.instrumentation.flask import FlaskInstrumentor
 
-from apitally.shared import activation, config, startup
+from apitally.shared import activation, config, server_errors, startup
 from apitally.shared.helpers import set_request_attribute
 from apitally.shared.wsgi import ApitallyWSGIMiddleware
 
@@ -40,6 +40,13 @@ def init(
             return
         if isinstance(app.wsgi_app, activation.WSGIActivationShim):
             return
+        original_handle_exception = app.handle_exception
+
+        def handle_exception(exception: Exception) -> Any:
+            server_errors.set_exception(exception)
+            return original_handle_exception(exception)
+
+        app.handle_exception = handle_exception  # ty: ignore[invalid-assignment]
         transport = ApitallyWSGIMiddleware(app.wsgi_app, get_route=_create_route_resolver(app))
         app.wsgi_app = transport  # ty: ignore[invalid-assignment]
         if not getattr(app, "_is_instrumented_by_opentelemetry", False):

--- a/apitally/litestar.py
+++ b/apitally/litestar.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Mapping
 from typing import TYPE_CHECKING
 
 from litestar.exceptions import HTTPException
@@ -15,7 +15,7 @@ from litestar.plugins.opentelemetry import (
 )
 from litestar.routes import HTTPRoute
 
-from apitally.shared import activation, config, startup
+from apitally.shared import activation, config, startup, validation_errors
 from apitally.shared.asgi import ApitallyASGIMiddleware
 from apitally.shared.context import get_server_span
 from apitally.shared.helpers import capture_exception
@@ -93,6 +93,7 @@ class ApitallyPlugin(InitPluginProtocol):
                         app.asgi_handler,  # ty: ignore[invalid-argument-type]
                         resolve_route=_resolve_route,  # ty: ignore[invalid-argument-type]
                         use_scope_client_address=True,
+                        validation_error_extractor=_extract_validation_errors,
                     )
                 )
             startup.set_app_info(
@@ -141,6 +142,33 @@ def _after_exception(exception: Exception, scope: Scope) -> None:
     if isinstance(exception, HTTPException) and exception.status_code < 500:
         return
     capture_exception(exception)
+
+
+def _extract_validation_errors(status_code: int, data: object) -> list[validation_errors.ValidationError]:
+    if status_code != 400 or not isinstance(data, Mapping):
+        return []
+    detail = data.get("detail")
+    extra = data.get("extra")
+    if not isinstance(detail, str) or "validation" not in detail.lower() or not isinstance(extra, list):
+        return []
+    errors = []
+    for error in extra:
+        if not isinstance(error, Mapping):
+            continue
+        source = error.get("source", "body")
+        key = error.get("key")
+        message = error.get("message")
+        if not isinstance(key, str) or not key or not isinstance(message, str) or not message:
+            continue
+        errors.append(
+            validation_errors.ValidationError(
+                source=validation_errors.SOURCE_ALIASES.get(source.lower(), "") if isinstance(source, str) else "",
+                field=key,
+                message=message,
+                type="",
+            )
+        )
+    return errors
 
 
 def _resolve_route(scope: Scope) -> str | None:

--- a/apitally/shared/activation.py
+++ b/apitally/shared/activation.py
@@ -16,7 +16,7 @@ from opentelemetry.sdk.resources import Resource
 from opentelemetry.sdk.trace import SpanProcessor
 from opentelemetry.sdk.trace.export import BatchSpanProcessor
 
-from apitally.shared import config, export, metrics, providers, sentry
+from apitally.shared import config, export, metrics, providers, sentry, server_errors, validation_errors
 from apitally.shared.config import TRUE_VALUES, ApitallyConfig
 from apitally.shared.consumer import consumer_holder_var
 from apitally.shared.context import server_span_kept_var, server_span_processor_var, server_span_var
@@ -234,7 +234,8 @@ def start_pipelines() -> None:
     log_processor = ApitallyLogRecordProcessor(create_batch_log_processor(spool), span_processor)
     logger_provider = providers.create_logger_provider(resource, [log_processor])
     install_root_handler(logger_provider, span_processor)
-    export_worker = ExportWorker(spool, span_processor, log_processor, env, proxy_urls=proxy_urls)
+    error_logger = logger_provider.get_logger("apitally")
+    export_worker = ExportWorker(spool, span_processor, log_processor, error_logger, env, proxy_urls=proxy_urls)
     export_worker.start()
 
 
@@ -284,6 +285,8 @@ def after_fork_in_child() -> None:
     global span_processor, log_processor, logger_provider, inherited_span_processor
     global spool, export_worker
     activation_lock = threading.Lock()
+    validation_errors.reset()
+    server_errors.reset()
     if not activated:  # pragma: no cover
         return
     try:
@@ -310,9 +313,11 @@ def reset() -> None:
     global spool, export_worker, proxy_urls
     activation_lock = threading.Lock()
     uninstall_root_handler()
-    metrics.reset()
     if export_worker is not None:
         export_worker.stop(timeout=1.0)
+    validation_errors.reset()
+    server_errors.reset()
+    metrics.reset()
     if span_processor is not None:
         span_processor.downstream.shutdown()
     if log_processor is not None:

--- a/apitally/shared/asgi.py
+++ b/apitally/shared/asgi.py
@@ -3,7 +3,7 @@ import time
 from collections.abc import Awaitable, Callable, Iterable
 from typing import Any
 
-from apitally.shared import metrics
+from apitally.shared import metrics, server_errors, validation_errors
 from apitally.shared.config import (
     BODY_TOO_LARGE,
     MAX_BODY_SIZE,
@@ -12,6 +12,7 @@ from apitally.shared.config import (
 )
 from apitally.shared.consumer import get_consumer_identifier, init_consumer, reset_consumer
 from apitally.shared.context import get_server_span, get_server_span_processor, is_server_span_kept
+from apitally.shared.validation_errors import ValidationError
 
 
 logger = logging.getLogger(__name__)
@@ -39,10 +40,12 @@ class ApitallyASGIMiddleware:
         app: ASGIApp,
         resolve_route: Callable[[Scope], str | None] | None = None,
         use_scope_client_address: bool = False,
+        validation_error_extractor: Callable[[int, object], list[ValidationError]] | None = None,
     ) -> None:
         self.app = app
         self.resolve_route = resolve_route or resolve_route_from_scope
         self.use_scope_client_address = use_scope_client_address
+        self.validation_error_extractor = validation_error_extractor
         self.config = get_config()
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
@@ -67,15 +70,19 @@ class ApitallyASGIMiddleware:
         response_size: int | None = None
         response_size_counter = 0
         response_headers: list[tuple[bytes, bytes]] | None = None
+        response_content_encoding: bytes | None = None
         response_body = bytearray()
         response_body_complete = False
         response_too_large = False
         capture_response = False
+        inspect_validation_response = False
         completed = False
         deferred_span_id: int | None = None
+        exception_holder = server_errors.ExceptionHolder()
 
         try:
             init_consumer()
+            exception_holder = server_errors.init_exception_holder()
             request_size = parse_int(get_header(request_headers, b"content-length"))
             capture_request = config.capture_request_body and is_allowed_content_type(
                 get_header(request_headers, b"content-type")
@@ -118,80 +125,107 @@ class ApitallyASGIMiddleware:
             if final_response_size is None and response_started:
                 final_response_size = response_size_counter
             try:
-                route = self.resolve_route(scope)
-            except Exception:  # pragma: no cover
-                logger.exception("Error resolving route in Apitally ASGI middleware")
-                route = None
-            if route:
-                root_path = str(scope.get("root_path") or "")
-                if root_path.startswith(initial_root_path):
-                    route = root_path[len(initial_root_path) :] + route
-            span = get_server_span()
-            processor = get_server_span_processor()
-            if (
-                is_server_span_kept()
-                and span is not None
-                and span.context is not None
-                and processor is not None
-                and (span.is_recording() or deferred_span_id is not None)
-            ):
-                extra_attributes: dict[str, str | int] = {}
-                if self.use_scope_client_address:
-                    client = scope.get("client")
-                    if isinstance(client, (list, tuple)) and client and isinstance(client[0], str) and client[0]:
-                        extra_attributes["client.address"] = client[0]
+                try:
+                    route = self.resolve_route(scope)
+                except Exception:  # pragma: no cover
+                    logger.exception("Error resolving route in Apitally ASGI middleware")
+                    route = None
                 if route:
-                    # Overwrites the instrumentor's raw route so spans and metrics agree on the template
-                    extra_attributes["http.route"] = route
-                    if span.is_recording():
-                        span.update_name(f"{scope.get('method', '')} {route}".strip())
-                if final_request_size is not None:
-                    extra_attributes["http.request.body.size"] = final_request_size
-                if final_response_size is not None:
-                    extra_attributes["http.response.body.size"] = final_response_size
-                # Partial buffers from aborted requests/responses are never exported
-                stash_request_headers = group_headers(request_headers) if config.capture_request_headers else None
-                stash_response_headers = group_headers(response_headers) if response_headers is not None else None
-                stash_request_body = (
-                    BODY_TOO_LARGE
-                    if request_too_large
-                    else (bytes(request_body) if capture_request and request_body and request_body_complete else None)
-                )
-                stash_response_body = (
-                    BODY_TOO_LARGE
-                    if response_too_large
-                    else (
-                        bytes(response_body) if capture_response and response_body and response_body_complete else None
+                    root_path = str(scope.get("root_path") or "")
+                    if root_path.startswith(initial_root_path):
+                        route = root_path[len(initial_root_path) :] + route
+                consumer = get_consumer_identifier()
+                span = get_server_span()
+                processor = get_server_span_processor()
+                if (
+                    is_server_span_kept()
+                    and span is not None
+                    and span.context is not None
+                    and processor is not None
+                    and (span.is_recording() or deferred_span_id is not None)
+                ):
+                    extra_attributes: dict[str, str | int] = {}
+                    if self.use_scope_client_address:
+                        client = scope.get("client")
+                        if isinstance(client, (list, tuple)) and client and isinstance(client[0], str) and client[0]:
+                            extra_attributes["client.address"] = client[0]
+                    if route:
+                        # Overwrites the instrumentor's raw route so spans and metrics agree on the template
+                        extra_attributes["http.route"] = route
+                        if span.is_recording():
+                            span.update_name(f"{scope.get('method', '')} {route}".strip())
+                    if final_request_size is not None:
+                        extra_attributes["http.request.body.size"] = final_request_size
+                    if final_response_size is not None:
+                        extra_attributes["http.response.body.size"] = final_response_size
+                    # Partial buffers from aborted requests/responses are never exported
+                    stash_request_headers = group_headers(request_headers) if config.capture_request_headers else None
+                    stash_response_headers = group_headers(response_headers) if response_headers is not None else None
+                    stash_request_body = (
+                        BODY_TOO_LARGE
+                        if request_too_large
+                        else (
+                            bytes(request_body) if capture_request and request_body and request_body_complete else None
+                        )
                     )
-                )
-                if stash_request_headers or stash_request_body or stash_response_headers or stash_response_body:
-                    processor.update_stash(
-                        span.context.span_id,
-                        request_headers=stash_request_headers,
-                        request_body=stash_request_body,
-                        response_headers=stash_response_headers,
-                        response_body=stash_response_body,
+                    stash_response_body = (
+                        BODY_TOO_LARGE
+                        if capture_response and response_too_large
+                        else (
+                            bytes(response_body)
+                            if capture_response and response_body and response_body_complete
+                            else None
+                        )
                     )
-                if deferred_span_id is not None:
-                    processor.finish_export(deferred_span_id, extra_attributes or None)
-                else:
-                    for key, value in extra_attributes.items():
-                        span.set_attribute(key, value)
-            metrics.record_request(
-                method=scope.get("method", ""),
-                route=route or "",
-                status_code=status,
-                consumer=get_consumer_identifier(),
-                duration=duration,
-                request_size=final_request_size,
-                response_size=final_response_size,
-                scheme=scope.get("scheme"),
-            )
-            reset_consumer()
+                    if stash_request_headers or stash_request_body or stash_response_headers or stash_response_body:
+                        processor.update_stash(
+                            span.context.span_id,
+                            request_headers=stash_request_headers,
+                            request_body=stash_request_body,
+                            response_headers=stash_response_headers,
+                            response_body=stash_response_body,
+                        )
+                    if deferred_span_id is not None:
+                        processor.finish_export(deferred_span_id, extra_attributes or None)
+                    else:
+                        for key, value in extra_attributes.items():
+                            span.set_attribute(key, value)
+                method = str(scope.get("method", ""))
+                if (
+                    inspect_validation_response
+                    and response_body_complete
+                    and not response_too_large
+                    and route
+                    and method.upper() != "OPTIONS"
+                    and self.validation_error_extractor is not None
+                ):
+                    data = validation_errors.decode_json_response(bytes(response_body), response_content_encoding)
+                    if data is not None:
+                        validation_errors.add_validation_errors(
+                            consumer,
+                            method,
+                            route,
+                            self.validation_error_extractor(status, data),
+                        )
+                if status == 500:
+                    server_errors.add_server_error(consumer, method, route, exception_holder)
+                metrics.record_request(
+                    method=method,
+                    route=route or "",
+                    status_code=status,
+                    consumer=consumer,
+                    duration=duration,
+                    request_size=final_request_size,
+                    response_size=final_response_size,
+                    scheme=scope.get("scheme"),
+                )
+            finally:
+                reset_consumer()
 
         async def send_wrapper(message: Message) -> None:
             nonlocal status, response_started, response_size, response_size_counter, response_headers
-            nonlocal response_body, response_body_complete, response_too_large, capture_response, deferred_span_id
+            nonlocal response_content_encoding, response_body, response_body_complete, response_too_large
+            nonlocal capture_response, inspect_validation_response, deferred_span_id
             try:
                 if message["type"] == "http.response.start":
                     response_started = True
@@ -201,14 +235,19 @@ class ApitallyASGIMiddleware:
                     if content_length is not None and get_header(headers, b"transfer-encoding") != b"chunked":
                         response_size = content_length
                     kept = is_server_span_kept()
-                    capture_response = (
-                        kept
-                        and config.capture_response_body
-                        and is_allowed_content_type(get_header(headers, b"content-type"))
+                    content_type = get_header(headers, b"content-type")
+                    capture_response = kept and config.capture_response_body and is_allowed_content_type(content_type)
+                    inspect_validation_response = (
+                        self.validation_error_extractor is not None
+                        and status in (400, 422)
+                        and validation_errors.is_json_content_type(content_type)
                     )
                     response_too_large = (
-                        capture_response and response_size is not None and response_size > MAX_BODY_SIZE
+                        (capture_response or inspect_validation_response)
+                        and response_size is not None
+                        and response_size > MAX_BODY_SIZE
                     )
+                    response_content_encoding = get_header(headers, b"content-encoding")
                     if kept and config.capture_response_headers:
                         response_headers = headers
                     if kept:
@@ -222,7 +261,7 @@ class ApitallyASGIMiddleware:
                 elif message["type"] == "http.response.body":
                     body = message.get("body", b"")
                     response_size_counter += len(body)
-                    if capture_response and not response_too_large:
+                    if (capture_response or inspect_validation_response) and not response_too_large:
                         response_body += body
                         if len(response_body) > MAX_BODY_SIZE:
                             response_too_large = True
@@ -238,14 +277,19 @@ class ApitallyASGIMiddleware:
         wrapped_receive = receive_wrapper if capture_request and not request_too_large else receive
         try:
             await self.app(scope, wrapped_receive, send_wrapper)
-        except BaseException:
-            status = status or 500
+        except BaseException as exc:
+            server_errors.set_exception(exc, exception_holder)
+            if not response_started:
+                status = 500
             raise
         finally:
             try:
                 finish()
             except Exception:  # pragma: no cover
                 logger.exception("Error in Apitally ASGI middleware")
+            # Outer Sentry middleware may add its event ID after this response is finalized.
+            if exception_holder.server_error_key is None:
+                server_errors.reset_exception_holder()
 
 
 def resolve_route_from_scope(scope: Scope) -> str | None:

--- a/apitally/shared/export.py
+++ b/apitally/shared/export.py
@@ -2,11 +2,13 @@ import atexit
 import logging
 import random
 import threading
+import time
 from collections.abc import Sequence
 from typing import Any, cast
 
 import requests
 from opentelemetry import context as otel_context
+from opentelemetry._logs import Logger
 from opentelemetry.context import _SUPPRESS_INSTRUMENTATION_KEY
 from opentelemetry.exporter.otlp.proto.common._log_encoder import encode_logs
 from opentelemetry.exporter.otlp.proto.common.trace_encoder import encode_spans
@@ -14,8 +16,9 @@ from opentelemetry.sdk._logs import ReadableLogRecord
 from opentelemetry.sdk._logs.export import LogRecordExporter, LogRecordExportResult
 from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.export import SpanExporter, SpanExportResult
+from opentelemetry.trace import INVALID_SPAN, set_span_in_context
 
-from apitally.shared import metrics
+from apitally.shared import metrics, server_errors, validation_errors
 from apitally.shared.log_processor import ApitallyLogRecordProcessor, truncate_log_record
 from apitally.shared.providers import DISTRO_VERSION, endpoint_url, export_headers
 from apitally.shared.span_processor import ApitallySpanProcessor
@@ -86,12 +89,14 @@ class ExportWorker:
         spool: Spool,
         span_processor: ApitallySpanProcessor,
         log_processor: ApitallyLogRecordProcessor,
+        error_logger: Logger,
         env: str,
         proxy_urls: dict[str, str] | None = None,
     ) -> None:
         self.spool = spool
         self.span_processor = span_processor
         self.log_processor = log_processor
+        self.error_logger = error_logger
         self.interval: float = DEFAULT_EXPORT_INTERVAL
         self.session = requests.Session()
         # Environment lookups per request would call macOS's _scproxy in forked workers, which crashes the process
@@ -121,7 +126,7 @@ class ExportWorker:
         self.thread.start()
         atexit.register(self.shutdown)
 
-    def stop(self, timeout: float = 5.0) -> None:
+    def stop(self, timeout: float | None = 5.0) -> None:
         atexit.unregister(self.shutdown)
         self.stop_event.set()
         if self.thread is not None and self.thread.is_alive():
@@ -129,7 +134,7 @@ class ExportWorker:
 
     def shutdown(self) -> None:
         """Stop the thread and attempt one final unpaced drain-and-send pass."""
-        self.stop()
+        self.stop(timeout=None)
         try:
             self.run_cycle(None, final=True)
         except Exception:  # pragma: no cover
@@ -150,6 +155,17 @@ class ExportWorker:
         token = otel_context.attach(otel_context.set_value(_SUPPRESS_INSTRUMENTATION_KEY, True))
         try:
             self.span_processor.downstream.force_flush()
+            for event_name, drain in (
+                (validation_errors.EVENT_NAME, validation_errors.drain_validation_errors),
+                (server_errors.EVENT_NAME, server_errors.drain_server_errors),
+            ):
+                for body in drain():
+                    self.error_logger.emit(
+                        timestamp=time.time_ns(),
+                        context=set_span_in_context(INVALID_SPAN),
+                        body=body,
+                        event_name=event_name,
+                    )
             self.log_processor.downstream.force_flush()
             if metrics.reader is not None:
                 metrics.reader.collect()

--- a/apitally/shared/helpers.py
+++ b/apitally/shared/helpers.py
@@ -2,6 +2,7 @@ import logging
 
 from opentelemetry.util.types import AttributeValue
 
+from apitally.shared import server_errors
 from apitally.shared.context import get_server_span
 
 
@@ -19,6 +20,7 @@ def set_request_attribute(key: str, value: AttributeValue) -> None:
 
 def capture_exception(exc: BaseException) -> None:
     try:
+        server_errors.set_exception(exc)
         span = get_server_span()
         if span is not None and span.is_recording():
             span.record_exception(exc)

--- a/apitally/shared/sentry.py
+++ b/apitally/shared/sentry.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING
 
+from apitally.shared import server_errors
 from apitally.shared.context import get_server_span, is_server_span_kept
 
 
@@ -37,6 +38,7 @@ def install() -> None:
 def sentry_event_processor(event: Event, hint: Hint) -> Event:
     try:
         if "exception" in event and (event_id := event.get("event_id")):
+            server_errors.set_sentry_event_id(event_id)
             span = get_server_span()
             if span is not None and span.context is not None and is_server_span_kept():
                 if len(pending_event_ids) >= MAX_PENDING_EVENT_IDS:  # pragma: no cover

--- a/apitally/shared/server_errors.py
+++ b/apitally/shared/server_errors.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import sys
+import threading
+import traceback
+from contextvars import ContextVar
+from dataclasses import dataclass
+from typing import Any
+
+
+if sys.version_info >= (3, 11):
+    exception_group_types: tuple[type[BaseExceptionGroup], ...] = (BaseExceptionGroup,)  # noqa: F821
+else:
+    try:
+        from exceptiongroup import BaseExceptionGroup as BackportBaseExceptionGroup
+
+        exception_group_types = (BackportBaseExceptionGroup,)
+    except ImportError:  # pragma: no cover
+        exception_group_types = ()
+
+EVENT_NAME = "apitally.request.server_error"
+MAX_GROUPS = 100
+MAX_METHOD_LENGTH = 12
+MAX_PATH_LENGTH = 2_000
+MAX_EXCEPTION_TYPE_LENGTH = 256
+MAX_EXCEPTION_MESSAGE_LENGTH = 2_048
+MAX_STACKTRACE_LENGTH = 65_536
+MAX_SENTRY_EVENT_ID_LENGTH = 32
+MAX_COUNT = 2**32 - 1
+MESSAGE_TRUNCATION_SUFFIX = "... (truncated)"
+STACKTRACE_TRUNCATION_PREFIX = "... (truncated) ...\n"
+
+
+@dataclass(slots=True, eq=False)
+class ExceptionHolder:
+    exception: BaseException | None = None
+    sentry_event_id: str | None = None
+    # Allows outer Sentry middleware to enrich an aggregate after request finalization.
+    server_error_key: ServerErrorKey | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ServerErrorKey:
+    consumer: str | None
+    method: str
+    path: str
+    type: str
+    message: str
+    stacktrace: str
+
+
+exception_holder_var: ContextVar[ExceptionHolder | None] = ContextVar("apitally_exception_holder", default=None)
+server_error_lock = threading.Lock()
+server_error_aggregates: dict[ServerErrorKey, tuple[int, str | None]] = {}
+
+
+def init_exception_holder() -> ExceptionHolder:
+    holder = ExceptionHolder()
+    exception_holder_var.set(holder)
+    return holder
+
+
+def reset_exception_holder() -> None:
+    exception_holder_var.set(None)
+
+
+def set_exception(exception: BaseException, holder: ExceptionHolder | None = None) -> None:
+    holder = holder or exception_holder_var.get()
+    if holder is None:
+        return
+    exception = collapse_exception_group(exception)
+    if holder.exception is not None and holder.exception is not exception:
+        holder.sentry_event_id = None
+        holder.server_error_key = None
+    holder.exception = exception
+
+
+def set_sentry_event_id(event_id: str) -> None:
+    holder = exception_holder_var.get()
+    if holder is None:
+        return
+    event_id = event_id.strip()[:MAX_SENTRY_EVENT_ID_LENGTH]
+    if not event_id:
+        return
+    holder.sentry_event_id = event_id
+    if holder.server_error_key is not None:
+        with server_error_lock:
+            aggregate = server_error_aggregates.get(holder.server_error_key)
+            if aggregate is not None:
+                server_error_aggregates[holder.server_error_key] = (aggregate[0], event_id)
+
+
+def collapse_exception_group(exception: BaseException) -> BaseException:
+    while isinstance(exception, exception_group_types) and len(exception.exceptions) == 1:  # ty: ignore[unresolved-attribute]
+        exception = exception.exceptions[0]  # ty: ignore[unresolved-attribute]
+    return exception
+
+
+def add_server_error(
+    consumer: str | None,
+    method: str,
+    path: str | None,
+    exception_holder: ExceptionHolder,
+) -> None:
+    if exception_holder.exception is None:
+        return
+    method = method.upper()
+    if method == "OPTIONS" or not path:
+        return
+    exception = exception_holder.exception
+    key = ServerErrorKey(
+        consumer=consumer,
+        method=method[:MAX_METHOD_LENGTH],
+        path=path[:MAX_PATH_LENGTH],
+        type=format_exception_type(exception),
+        message=format_exception_message(exception),
+        stacktrace=format_exception_stacktrace(exception),
+    )
+    with server_error_lock:
+        aggregate = server_error_aggregates.get(key)
+        if aggregate is not None:
+            count, sentry_event_id = aggregate
+            server_error_aggregates[key] = (
+                count + 1,
+                exception_holder.sentry_event_id or sentry_event_id,
+            )
+        elif len(server_error_aggregates) < MAX_GROUPS:
+            server_error_aggregates[key] = (1, exception_holder.sentry_event_id)
+        else:
+            return
+        exception_holder.server_error_key = key
+
+
+def drain_server_errors() -> list[dict[str, Any]]:
+    global server_error_aggregates
+    with server_error_lock:
+        aggregates = server_error_aggregates
+        server_error_aggregates = {}
+    events = []
+    for error, (count, sentry_event_id) in aggregates.items():
+        body: dict[str, Any] = {
+            "method": error.method,
+            "path": error.path,
+            "type": error.type,
+            "message": error.message,
+            "stacktrace": error.stacktrace,
+            "count": min(count, MAX_COUNT),
+        }
+        if error.consumer is not None:
+            body["consumer"] = error.consumer
+        if sentry_event_id is not None:
+            body["sentry_event_id"] = sentry_event_id
+        events.append(body)
+    return events
+
+
+def reset() -> None:
+    global server_error_aggregates, server_error_lock
+    server_error_aggregates = {}
+    server_error_lock = threading.Lock()
+    reset_exception_holder()
+
+
+def format_exception_type(exception: BaseException) -> str:
+    exception_type = type(exception)
+    return f"{exception_type.__module__}.{exception_type.__qualname__}"[:MAX_EXCEPTION_TYPE_LENGTH]
+
+
+def format_exception_message(exception: BaseException) -> str:
+    message = str(exception).strip()
+    if len(message) <= MAX_EXCEPTION_MESSAGE_LENGTH:
+        return message
+    cutoff = MAX_EXCEPTION_MESSAGE_LENGTH - len(MESSAGE_TRUNCATION_SUFFIX)
+    return message[:cutoff] + MESSAGE_TRUNCATION_SUFFIX
+
+
+def format_exception_stacktrace(exception: BaseException) -> str:
+    traceback_lines = traceback.format_exception(exception)
+    if sum(map(len, traceback_lines)) <= MAX_STACKTRACE_LENGTH:
+        return "".join(traceback_lines).strip()
+    cutoff = MAX_STACKTRACE_LENGTH - len(STACKTRACE_TRUNCATION_PREFIX)
+    lines = []
+    length = 0
+    for line in reversed(traceback_lines):
+        if length + len(line) > cutoff:
+            lines.append(STACKTRACE_TRUNCATION_PREFIX)
+            break
+        lines.append(line)
+        length += len(line)
+    return "".join(reversed(lines)).strip()

--- a/apitally/shared/span_processor.py
+++ b/apitally/shared/span_processor.py
@@ -1,5 +1,4 @@
 import logging
-import sys
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from functools import lru_cache, partial
@@ -13,6 +12,7 @@ from opentelemetry.sdk.trace.sampling import TraceIdRatioBased
 from opentelemetry.trace import SpanContext, SpanKind
 from opentelemetry.util.types import AttributeValue
 
+from apitally.shared import server_errors
 from apitally.shared.config import get_config
 from apitally.shared.consumer import consumer_holder_var, write_consumer_span_attributes
 from apitally.shared.context import (
@@ -23,16 +23,6 @@ from apitally.shared.context import (
 )
 from apitally.shared.redaction import combine_patterns, compile_patterns, matches_any
 
-
-if sys.version_info >= (3, 11):
-    _exception_group_types: tuple[type[BaseExceptionGroup], ...] = (BaseExceptionGroup,)  # noqa: F821
-else:
-    try:
-        from exceptiongroup import BaseExceptionGroup as _BaseExceptionGroup
-
-        _exception_group_types = (_BaseExceptionGroup,)
-    except ImportError:  # pragma: no cover
-        _exception_group_types = ()
 
 logger = logging.getLogger(__name__)
 
@@ -89,9 +79,7 @@ def record_collapsed_exception(
     record_exception: Callable[..., None], exception: BaseException, *args: Any, **kwargs: Any
 ) -> None:
     """Unwraps single-leaf ExceptionGroups before recording the exception on the span."""
-    while isinstance(exception, _exception_group_types) and len(exception.exceptions) == 1:  # ty: ignore[unresolved-attribute]
-        exception = exception.exceptions[0]  # ty: ignore[unresolved-attribute]
-    record_exception(exception, *args, **kwargs)
+    record_exception(server_errors.collapse_exception_group(exception), *args, **kwargs)
 
 
 class ApitallySpanProcessor(SpanProcessor):

--- a/apitally/shared/validation_errors.py
+++ b/apitally/shared/validation_errors.py
@@ -1,0 +1,182 @@
+from __future__ import annotations
+
+import gzip
+import json
+import threading
+from collections.abc import Mapping
+from dataclasses import dataclass
+from io import BytesIO
+from typing import Any
+
+from apitally.shared.config import MAX_BODY_SIZE
+
+
+EVENT_NAME = "apitally.request.validation_error"
+MAX_GROUPS = 100
+MAX_METHOD_LENGTH = 12
+MAX_PATH_LENGTH = 2_000
+MAX_SOURCE_LENGTH = 32
+MAX_FIELD_LENGTH = 2_048
+MAX_MESSAGE_LENGTH = 2_048
+MAX_TYPE_LENGTH = 128
+MAX_COUNT = 2**32 - 1
+
+SOURCE_ALIASES = {
+    "body": "body",
+    "query": "query",
+    "path": "path",
+    "header": "header",
+    "cookie": "cookie",
+    "querystring": "query",
+    "params": "path",
+    "path_params": "path",
+    "headers": "header",
+    "cookies": "cookie",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationError:
+    source: str
+    field: str
+    message: str
+    type: str
+
+
+@dataclass(frozen=True, slots=True)
+class ValidationErrorKey:
+    consumer: str | None
+    method: str
+    path: str
+    source: str
+    field: str
+    message: str
+    type: str
+
+
+validation_error_lock = threading.Lock()
+validation_error_counts: dict[ValidationErrorKey, int] = {}
+
+
+def add_validation_errors(
+    consumer: str | None,
+    method: str,
+    path: str,
+    validation_errors: list[ValidationError],
+) -> None:
+    if not validation_errors:
+        return
+    method = method.upper()[:MAX_METHOD_LENGTH]
+    path = path[:MAX_PATH_LENGTH]
+    with validation_error_lock:
+        for error in validation_errors:
+            key = ValidationErrorKey(
+                consumer=consumer,
+                method=method,
+                path=path,
+                source=error.source[:MAX_SOURCE_LENGTH],
+                field=error.field[:MAX_FIELD_LENGTH],
+                message=error.message[:MAX_MESSAGE_LENGTH],
+                type=error.type[:MAX_TYPE_LENGTH],
+            )
+            if key in validation_error_counts:
+                validation_error_counts[key] += 1
+            elif len(validation_error_counts) < MAX_GROUPS:
+                validation_error_counts[key] = 1
+
+
+def drain_validation_errors() -> list[dict[str, Any]]:
+    global validation_error_counts
+    with validation_error_lock:
+        counts = validation_error_counts
+        validation_error_counts = {}
+    events = []
+    for error, count in counts.items():
+        body: dict[str, Any] = {
+            "method": error.method,
+            "path": error.path,
+            "source": error.source,
+            "field": error.field,
+            "message": error.message,
+            "type": error.type,
+            "count": min(count, MAX_COUNT),
+        }
+        if error.consumer is not None:
+            body["consumer"] = error.consumer
+        events.append(body)
+    return events
+
+
+def reset() -> None:
+    global validation_error_counts, validation_error_lock
+    validation_error_counts = {}
+    validation_error_lock = threading.Lock()
+
+
+def format_location(location: object) -> tuple[str, str]:
+    if not isinstance(location, list) or not location:
+        return "", ""
+    source = ""
+    start = 0
+    if isinstance(location[0], str):
+        source = SOURCE_ALIASES.get(location[0].lower(), "")
+        if source:
+            start = 1
+    field = ".".join(
+        str(segment)
+        for segment in location[start:]
+        if isinstance(segment, (str, int)) and not isinstance(segment, bool)
+    )
+    return source, field
+
+
+def extract_pydantic_validation_errors(data: object) -> list[ValidationError]:
+    if not isinstance(data, Mapping):
+        return []
+    details = data.get("detail")
+    if not isinstance(details, list):
+        return []
+    errors = []
+    for detail in details:
+        if not isinstance(detail, Mapping) or not all(key in detail for key in ("loc", "msg", "type")):
+            continue
+        source, field = format_location(detail.get("loc"))
+        message = detail.get("msg")
+        error_type = detail.get("type")
+        errors.append(
+            ValidationError(
+                source=source,
+                field=field,
+                message=message if isinstance(message, str) else "",
+                type=error_type if isinstance(error_type, str) else "",
+            )
+        )
+    return errors
+
+
+def is_json_content_type(content_type: str | bytes | None) -> bool:
+    if isinstance(content_type, bytes):
+        content_type = content_type.decode("latin1")
+    if not content_type:
+        return False
+    media_type = content_type.partition(";")[0].strip().lower()
+    return media_type == "application/json" or (media_type.startswith("application/") and media_type.endswith("+json"))
+
+
+def decode_json_response(body: bytes, content_encoding: str | bytes | None) -> object | None:
+    if len(body) > MAX_BODY_SIZE:
+        return None
+    if isinstance(content_encoding, bytes):
+        content_encoding = content_encoding.decode("latin1")
+    encoding = content_encoding.strip().lower() if content_encoding else ""
+    try:
+        if encoding == "gzip":
+            with gzip.GzipFile(fileobj=BytesIO(body)) as gzip_file:
+                body = gzip_file.read(MAX_BODY_SIZE + 1)
+        elif encoding not in ("", "identity"):
+            return None
+        if len(body) > MAX_BODY_SIZE:
+            return None
+        return json.loads(body)
+    except Exception:
+        return None

--- a/apitally/shared/wsgi.py
+++ b/apitally/shared/wsgi.py
@@ -4,10 +4,10 @@ import io
 import logging
 import time
 from collections.abc import Callable, Iterable, Iterator
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import TYPE_CHECKING
 
-from apitally.shared import metrics
+from apitally.shared import metrics, server_errors
 from apitally.shared.config import (
     BODY_TOO_LARGE,
     MAX_BODY_SIZE,
@@ -41,9 +41,11 @@ class ApitallyWSGIMiddleware:
 
     def __call__(self, environ: WSGIEnvironment, start_response: StartResponse) -> Iterable[bytes]:
         config = self.config
-        state = RequestState()
+        start_time = time.perf_counter()
+        init_consumer()
+        exception_holder = server_errors.init_exception_holder()
+        state = RequestState(start_time, exception_holder)
         try:
-            init_consumer()
             state.request_size = parse_content_length(environ.get("CONTENT_LENGTH"))
             state.request_body = self.capture_request_body(environ, config, state.request_size)
         except Exception:  # pragma: no cover
@@ -60,9 +62,11 @@ class ApitallyWSGIMiddleware:
 
         try:
             response = self.app(environ, wrapped_start_response)
-        except BaseException:
+        except BaseException as exc:
             # No ResponseWrapper is created, so finalize here to release the deferral and record metrics
-            state.status_code = state.status_code or 500
+            server_errors.set_exception(exc, state.exception_holder)
+            if not state.status_code:
+                state.status_code = 500
             self.finalize(environ, state)
             raise
         return ResponseWrapper(response, self, environ, state)
@@ -155,11 +159,15 @@ class ApitallyWSGIMiddleware:
             if state.deferred_span_id is not None and processor is not None:
                 processor.finish_export(state.deferred_span_id, extra or None)
             route = self.get_route(environ) if self.get_route is not None else None
+            method = environ.get("REQUEST_METHOD", "")
+            consumer = get_consumer_identifier()
+            if state.status_code == 500:
+                server_errors.add_server_error(consumer, method, route, state.exception_holder)
             metrics.record_request(
-                method=environ.get("REQUEST_METHOD", ""),
+                method=method,
                 route=route or "",
                 status_code=state.status_code,
-                consumer=get_consumer_identifier(),
+                consumer=consumer,
                 duration=duration,
                 request_size=state.request_size,
                 response_size=state.response_size,
@@ -168,8 +176,9 @@ class ApitallyWSGIMiddleware:
         except Exception:  # pragma: no cover
             logger.exception("Error in Apitally WSGI middleware")
         finally:
-            # A reused worker thread keeps its context; the holder must not survive into the next request
+            # A reused worker thread keeps its context; the holders must not survive into the next request
             reset_consumer()
+            server_errors.reset_exception_holder()
 
 
 class ResponseWrapper:
@@ -196,6 +205,12 @@ class ResponseWrapper:
             self.state.completed = True
             self.middleware.finalize(self.environ, self.state)
             raise
+        except BaseException as exc:
+            server_errors.set_exception(exc, self.state.exception_holder)
+            if not self.state.status_code:
+                self.state.status_code = 500
+            self.middleware.finalize(self.environ, self.state)
+            raise
         try:
             self.state.bytes_sent += len(chunk)
             if isinstance(self.state.response_body, bytearray):
@@ -215,7 +230,8 @@ class ResponseWrapper:
 
 @dataclass(slots=True)
 class RequestState:
-    start_time: float = field(default_factory=time.perf_counter)
+    start_time: float
+    exception_holder: server_errors.ExceptionHolder
     status_code: int = 0
     request_size: int | None = None
     request_body: bytes | None = None

--- a/apitally/starlette.py
+++ b/apitally/starlette.py
@@ -13,8 +13,9 @@ from starlette.middleware.errors import ServerErrorMiddleware
 from starlette.routing import Match
 from starlette.schemas import SchemaGenerator
 
-from apitally.shared import activation, config, startup
+from apitally.shared import activation, config, startup, validation_errors
 from apitally.shared.asgi import ApitallyASGIMiddleware
+from apitally.shared.helpers import capture_exception
 
 
 if TYPE_CHECKING:
@@ -68,6 +69,7 @@ def _instrument_app(app: Starlette) -> None:
                 ApitallyASGIMiddleware,
                 resolve_route=_resolve_route,
                 use_scope_client_address=True,
+                validation_error_extractor=_extract_validation_errors,
             ),
         )
         app.user_middleware.insert(0, Middleware(activation.ASGIActivationShim))
@@ -96,6 +98,7 @@ def _instrument_app(app: Starlette) -> None:
                 ),
                 resolve_route=_resolve_route,
                 use_scope_client_address=True,
+                validation_error_extractor=_extract_validation_errors,
             )
         )
 
@@ -113,11 +116,17 @@ class _ExceptionRecordingMiddleware:
         try:
             await self.app(scope, receive, send)
         except Exception as exc:
+            capture_exception(exc)
             span = trace.get_current_span()
             if span.is_recording():
-                span.record_exception(exc)
                 span.set_status(Status(StatusCode.ERROR, f"{type(exc).__name__}: {exc}"))
             raise
+
+
+def _extract_validation_errors(status_code: int, data: object) -> list[validation_errors.ValidationError]:
+    if status_code != 422:
+        return []
+    return validation_errors.extract_pydantic_validation_errors(data)
 
 
 def _get_default_span_details(scope: Scope) -> tuple[str, dict[str, Any]]:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,7 +28,7 @@ from opentelemetry.sdk.trace.sampling import ALWAYS_ON, Sampler
 from opentelemetry.test.globals_test import reset_trace_globals
 from opentelemetry.trace import SpanKind, Tracer
 
-from apitally.shared import activation, config, export, metrics, providers, startup
+from apitally.shared import activation, config, export, metrics, providers, server_errors, startup, validation_errors
 from apitally.shared.consumer import consumer_holder_var
 from apitally.shared.context import server_span_kept_var, server_span_processor_var, server_span_var
 from apitally.shared.exporter import ApitallySpanExporter
@@ -177,7 +177,7 @@ def exporters(monkeypatch: pytest.MonkeyPatch) -> InMemoryExporters:
     monkeypatch.setattr(export, "create_span_exporter", span_exporter)
     monkeypatch.setattr(export, "create_log_exporter", log_exporter)
     monkeypatch.setattr(export.ExportWorker, "start", lambda self: None)
-    monkeypatch.setattr(export.ExportWorker, "send_pending", lambda self, stop_event: None)
+    monkeypatch.setattr(export.ExportWorker, "send_pending", lambda self, stop_event, cap=True: None)
     return created
 
 
@@ -296,6 +296,12 @@ def exported_spans(exporters: InMemoryExporters, kind: SpanKind | None = None) -
 def exported_log_records(exporters: InMemoryExporters) -> list[LogRecord]:
     unwrap(activation.log_processor).force_flush()
     return [exported.log_record for exporter in exporters.log for exported in exporter.get_finished_logs()]
+
+
+def exported_error_records(exporters: InMemoryExporters) -> list[LogRecord]:
+    unwrap(activation.export_worker).run_cycle(None)
+    event_names = {validation_errors.EVENT_NAME, server_errors.EVENT_NAME}
+    return [record for record in exported_log_records(exporters) if record.event_name in event_names]
 
 
 def startup_payload(exporters: InMemoryExporters) -> dict[str, Any]:

--- a/tests/django/urls.py
+++ b/tests/django/urls.py
@@ -1,4 +1,5 @@
 import json
+from collections.abc import Iterator
 
 from django.http import HttpRequest, HttpResponse, JsonResponse, StreamingHttpResponse
 from django.urls import include, path
@@ -16,6 +17,13 @@ def create_item(request: HttpRequest) -> JsonResponse:
 
 
 def stream(request: HttpRequest) -> StreamingHttpResponse:
+    if "fail" in request.GET:
+
+        def content() -> Iterator[bytes]:
+            yield b"chunk1"
+            raise RuntimeError("stream failed")
+
+        return StreamingHttpResponse(content(), status=500, content_type="text/plain")
     return StreamingHttpResponse(iter([b"chunk1", b"chunk2"]), content_type="text/plain")
 
 

--- a/tests/shared/test_activation.py
+++ b/tests/shared/test_activation.py
@@ -18,11 +18,12 @@ from opentelemetry.sdk.trace.export import SimpleSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind
 
-from apitally.shared import activation, export, log_processor, metrics
+from apitally.shared import activation, export, log_processor, metrics, server_errors, validation_errors
 from apitally.shared.asgi import Message, Receive, Scope, Send
 from apitally.shared.consumer import ConsumerHolder, consumer_holder_var
 from apitally.shared.context import server_span_kept_var, server_span_processor_var, server_span_var
 from apitally.shared.span_processor import ApitallySpanProcessor
+from apitally.shared.validation_errors import ValidationError
 from tests.conftest import (
     WRITE_TOKEN,
     InMemoryExporters,
@@ -340,6 +341,10 @@ def test_child_reactivation_clears_inherited_request_state(
 ):
     configure_and_activate(monkeypatch)
     span = trace.get_tracer("test").start_span("GET /items", kind=SpanKind.SERVER)  # in flight at fork
+    holder = server_errors.init_exception_holder()
+    server_errors.set_exception(RuntimeError("inherited"), holder)
+    server_errors.add_server_error(None, "GET", "/items", holder)
+    validation_errors.add_validation_errors(None, "POST", "/items", [ValidationError("body", "name", "x", "")])
 
     activation.before_fork()
     activation.after_fork_in_child()
@@ -348,6 +353,9 @@ def test_child_reactivation_clears_inherited_request_state(
     assert activation.span_processor is not None
     assert not activation.span_processor.spans
     assert not activation.span_processor.pending
+    assert server_errors.exception_holder_var.get() is None
+    assert server_errors.drain_server_errors() == []
+    assert validation_errors.drain_validation_errors() == []
     span.end()
     assert exporters.span[-1].get_finished_spans() == ()
 
@@ -431,6 +439,10 @@ def test_reset_stops_worker_and_removes_spool_files(otlp_server: StubOTLPServer,
     activation.configure(write_token=WRITE_TOKEN, otlp_endpoint=otlp_server.url)
     activation.activate()
     assert len(set(threading.enumerate()) - threads_before) == 3
+    holder = server_errors.init_exception_holder()
+    server_errors.set_exception(RuntimeError("pending"), holder)
+    server_errors.add_server_error(None, "GET", "/items", holder)
+    validation_errors.add_validation_errors(None, "POST", "/items", [ValidationError("body", "name", "x", "")])
     with trace.get_tracer("test").start_as_current_span("GET /items", kind=SpanKind.SERVER):
         pass
     spool = unwrap(activation.spool)
@@ -441,3 +453,6 @@ def test_reset_stops_worker_and_removes_spool_files(otlp_server: StubOTLPServer,
     activation.reset()
     assert not any(thread.name == "ApitallyExportWorker" and thread.is_alive() for thread in threading.enumerate())
     assert not any(path.exists() for path in paths)
+    assert server_errors.exception_holder_var.get() is None
+    assert server_errors.drain_server_errors() == []
+    assert validation_errors.drain_validation_errors() == []

--- a/tests/shared/test_asgi.py
+++ b/tests/shared/test_asgi.py
@@ -9,15 +9,19 @@ from opentelemetry.sdk.trace import ReadableSpan
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON, Sampler, TraceIdRatioBased
 from opentelemetry.trace import SpanKind, Tracer
 
-from apitally.shared import config, metrics
+from apitally.shared import config, metrics, server_errors, validation_errors
 from apitally.shared.asgi import ApitallyASGIMiddleware
-from apitally.shared.config import BODY_TOO_LARGE, set_config
+from apitally.shared.config import BODY_TOO_LARGE, MAX_BODY_SIZE, set_config
 from apitally.shared.consumer import set_consumer
 from apitally.shared.redaction import REDACTED
 from tests.conftest import WRITE_TOKEN, collect_metrics, create_trace_pipeline, setup_metric_reader
 
 
 JSON_HEADERS = [("content-type", "application/json")]
+
+
+def extract_validation_errors(status_code: int, data: object) -> list[validation_errors.ValidationError]:
+    return validation_errors.extract_pydantic_validation_errors(data)
 
 
 @pytest.fixture(autouse=True)
@@ -83,13 +87,14 @@ def make_scope(
 
 async def send_request(
     tracer: Tracer,
-    app: EchoApp,
+    app: Any,
     request_headers: list[tuple[str, str]] | None = None,
     request_chunks: list[bytes] | None = None,
     method: str = "POST",
     route: str = "/items",
+    validation_error_extractor: Any = None,
 ) -> list[dict[str, Any]]:
-    middleware = ApitallyASGIMiddleware(app)
+    middleware = ApitallyASGIMiddleware(app, validation_error_extractor=validation_error_extractor)
     scope = make_scope(method=method, route=route, headers=request_headers)
     chunks = request_chunks or [b""]
     messages = [
@@ -448,3 +453,175 @@ async def test_sampled_out_request_skips_capture(metric_reader: InMemoryMetricRe
     assert isinstance(duration_metric.data, ExponentialHistogram)
     (point,) = duration_metric.data.data_points
     assert point.count == 1
+
+
+async def test_validation_response_buffer_is_independent_of_trace_body_capture():
+    set_config(write_token=WRITE_TOKEN)
+    tracer, exporter = create_trace_pipeline()
+    app = EchoApp(
+        status=422,
+        response_headers=JSON_HEADERS,
+        response_chunks=[b'{"detail":[{"loc":["body","name"],"msg":"required","type":"missing"}]}'],
+    )
+    await send_request(
+        tracer,
+        app,
+        validation_error_extractor=extract_validation_errors,
+    )
+
+    assert validation_errors.drain_validation_errors() == [
+        {
+            "method": "POST",
+            "path": "/items",
+            "source": "body",
+            "field": "name",
+            "message": "required",
+            "type": "missing",
+            "count": 1,
+        }
+    ]
+    (span,) = exporter.get_finished_spans()
+    assert "apitally.response.body" not in (span.attributes or {})
+
+
+@pytest.mark.parametrize("response", ["non-json", "ineligible", "over-cap", "incomplete"])
+async def test_ineligible_validation_responses_produce_no_occurrence_or_trace_stash(response: str):
+    set_config(write_token=WRITE_TOKEN)
+    tracer, exporter = create_trace_pipeline()
+    body = b'{"detail":[{"loc":["body","name"],"msg":"required","type":"missing"}]}'
+    status = 200 if response == "ineligible" else 422
+    headers = [("content-type", "text/plain")] if response == "non-json" else JSON_HEADERS
+    if response == "over-cap":
+        body = b'{"detail":[],"padding":"' + b"x" * MAX_BODY_SIZE + b'"}'
+    if response == "incomplete":
+
+        async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+            await send(
+                {
+                    "type": "http.response.start",
+                    "status": 422,
+                    "headers": [(b"content-type", b"application/json")],
+                }
+            )
+            await send({"type": "http.response.body", "body": body, "more_body": True})
+
+    else:
+        app = EchoApp(status=status, response_headers=headers, response_chunks=[body])
+    await send_request(
+        tracer,
+        app,
+        validation_error_extractor=extract_validation_errors,
+    )
+
+    assert validation_errors.drain_validation_errors() == []
+    (span,) = exporter.get_finished_spans()
+    assert "apitally.response.body" not in (span.attributes or {})
+
+
+@pytest.mark.parametrize("error_kind", ["validation", "server"])
+@pytest.mark.parametrize("drop_kind", ["response", "user-sampler"])
+async def test_error_aggregation_does_not_require_exported_trace(error_kind: str, drop_kind: str):
+    config_kwargs = {"sample_on_response": lambda span: False} if drop_kind == "response" else {}
+    sampler = TraceIdRatioBased(0.0) if drop_kind == "user-sampler" else ALWAYS_ON
+    set_config(write_token=WRITE_TOKEN, **config_kwargs)
+    tracer, exporter = create_trace_pipeline(sampler=sampler)
+    if error_kind == "validation":
+        app: Any = EchoApp(
+            status=422,
+            response_headers=JSON_HEADERS,
+            response_chunks=[b'{"detail":[{"loc":["query","page"],"msg":"invalid","type":"int"}]}'],
+        )
+        extractor = extract_validation_errors
+    else:
+
+        async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+            raise RuntimeError("boom")
+
+        extractor = None
+
+    if error_kind == "server":
+        with pytest.raises(RuntimeError):
+            await send_request(tracer, app, method="GET", validation_error_extractor=extractor)
+    else:
+        await send_request(tracer, app, method="GET", validation_error_extractor=extractor)
+
+    assert exporter.get_finished_spans() == ()
+    validation_events = validation_errors.drain_validation_errors()
+    server_events = server_errors.drain_server_errors()
+    assert len(validation_events if error_kind == "validation" else server_events) == 1
+    assert (server_events if error_kind == "validation" else validation_events) == []
+
+
+async def test_asgi_exception_before_response_uses_500_and_accepts_late_sentry_id():
+    set_config(write_token=WRITE_TOKEN)
+    tracer, _ = create_trace_pipeline()
+
+    async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        raise RuntimeError("before")
+
+    with pytest.raises(RuntimeError):
+        await send_request(tracer, app, method="GET")
+    server_errors.set_sentry_event_id("late-event-id")
+    (event,) = server_errors.drain_server_errors()
+    assert event["message"] == "before"
+    assert event["sentry_event_id"] == "late-event-id"
+
+
+async def test_asgi_exception_after_response_start_adds_no_server_error():
+    set_config(write_token=WRITE_TOKEN)
+    tracer, _ = create_trace_pipeline()
+
+    async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        await send({"type": "http.response.start", "status": 200, "headers": []})
+        raise RuntimeError("after")
+
+    with pytest.raises(RuntimeError):
+        await send_request(tracer, app, method="GET")
+    assert server_errors.drain_server_errors() == []
+
+
+@pytest.mark.parametrize("error_kind", ["validation", "server"])
+@pytest.mark.parametrize(("method", "route"), [("OPTIONS", "/items"), ("GET", "")])
+async def test_options_and_unmatched_routes_add_no_error_groups(error_kind: str, method: str, route: str):
+    set_config(write_token=WRITE_TOKEN)
+    tracer, _ = create_trace_pipeline()
+    if error_kind == "validation":
+        app: Any = EchoApp(
+            status=422,
+            response_headers=JSON_HEADERS,
+            response_chunks=[b'{"detail":[{"loc":["query","page"],"msg":"invalid","type":"int"}]}'],
+        )
+        await send_request(
+            tracer,
+            app,
+            method=method,
+            route=route,
+            validation_error_extractor=extract_validation_errors,
+        )
+    else:
+
+        async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+            raise RuntimeError("boom")
+
+        with pytest.raises(RuntimeError):
+            await send_request(tracer, app, method=method, route=route)
+    assert validation_errors.drain_validation_errors() == []
+    assert server_errors.drain_server_errors() == []
+
+
+async def test_terminal_completion_adds_once_and_ignores_later_exception():
+    set_config(write_token=WRITE_TOKEN)
+    tracer, _ = create_trace_pipeline()
+
+    async def app(scope: dict[str, Any], receive: Any, send: Any) -> None:
+        server_errors.set_exception(RuntimeError("boom"))
+        await send({"type": "http.response.start", "status": 500, "headers": []})
+        await send({"type": "http.response.body", "body": b"error", "more_body": False})
+        server_errors.set_exception(RuntimeError("late"))
+        server_errors.set_sentry_event_id("late-event-id")
+
+    await send_request(tracer, app, method="GET")
+    (event,) = server_errors.drain_server_errors()
+    assert event["message"] == "boom"
+    assert "sentry_event_id" not in event
+    assert event["count"] == 1

--- a/tests/shared/test_export.py
+++ b/tests/shared/test_export.py
@@ -25,7 +25,7 @@ from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.trace import SpanKind
 
 import apitally
-from apitally.shared import activation, export, metrics, startup
+from apitally.shared import activation, export, metrics, server_errors, startup, validation_errors
 from apitally.shared.config import set_config
 from apitally.shared.context import get_server_span_processor
 from apitally.shared.export import (
@@ -42,8 +42,10 @@ from apitally.shared.export import (
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.log_processor import MAX_LOG_VALUE_LENGTH
 from apitally.shared.redaction import REDACTED
+from apitally.shared.server_errors import ExceptionHolder
 from apitally.shared.span_processor import ApitallySpanProcessor
 from apitally.shared.spool import MAX_RETRY_TIME_AFTER_FIRST_ATTEMPT, MAX_UNCOMPRESSED_FILE_SIZE, Spool
+from apitally.shared.validation_errors import ValidationError
 from tests.conftest import (
     CONTRIB_SCOPE,
     INSTANCE_ID,
@@ -62,10 +64,16 @@ def spool() -> Iterator[Spool]:
     spool.clear()
 
 
-def make_worker(spool: Spool, endpoint: str) -> ExportWorker:
-    set_config(write_token=WRITE_TOKEN, env="dev", otlp_endpoint=endpoint)
+def make_worker(spool: Spool, endpoint: str, **config_kwargs: Any) -> ExportWorker:
+    set_config(write_token=WRITE_TOKEN, env="dev", otlp_endpoint=endpoint, **config_kwargs)
     processor_stub = SimpleNamespace(downstream=SimpleNamespace(force_flush=lambda timeout_millis=30_000: True))
-    return ExportWorker(spool, cast("Any", processor_stub), cast("Any", processor_stub), env="dev")
+    return ExportWorker(
+        spool,
+        cast("Any", processor_stub),
+        cast("Any", processor_stub),
+        make_log_provider(spool).get_logger("apitally"),
+        env="dev",
+    )
 
 
 def read_trace_request(spool: Spool) -> ExportTraceServiceRequest:
@@ -197,6 +205,45 @@ def test_export_cycle_posts_all_three_signals_in_lockstep(spool: Spool, otlp_ser
     assert headers["User-Agent"].startswith("apitally-py/")
     assert gzip.decompress(body) == b"trace-payload"
     assert spool.pending_files() == []
+
+
+def test_export_cycle_emits_structured_error_events_without_trace_context(
+    spool: Spool, otlp_server: StubOTLPServer
+) -> None:
+    worker = make_worker(spool, otlp_server.url, capture_logs=False)
+    validation_errors.add_validation_errors(
+        "consumer",
+        "post",
+        "/items",
+        [ValidationError("body", "name", "required", "missing")],
+    )
+    server_errors.add_server_error(
+        "consumer",
+        "GET",
+        "/items",
+        ExceptionHolder(RuntimeError("boom"), "event-id"),
+    )
+
+    worker.run_cycle(None)
+
+    (request_body,) = [body for path, _, body in otlp_server.requests if path == "/v1/logs"]
+    request = ExportLogsServiceRequest.FromString(gzip.decompress(request_body))
+    scope_logs = [scope_logs for resource in request.resource_logs for scope_logs in resource.scope_logs]
+    assert {scope.scope.name for scope in scope_logs} == {"apitally"}
+    records = [record for scope in scope_logs for record in scope.log_records]
+    assert {record.event_name for record in records} == {
+        validation_errors.EVENT_NAME,
+        server_errors.EVENT_NAME,
+    }
+    for record in records:
+        assert record.time_unix_nano > 0
+        assert record.trace_id == b""
+        assert record.span_id == b""
+        assert record.body.WhichOneof("value") == "kvlist_value"
+        keys = {entry.key for entry in record.body.kvlist_value.values}
+        assert {"method", "path", "count"} < keys
+    assert validation_errors.drain_validation_errors() == []
+    assert server_errors.drain_server_errors() == []
 
 
 def test_failed_send_retries_next_cycle_with_identical_bytes(spool: Spool, otlp_server: StubOTLPServer) -> None:
@@ -336,7 +383,13 @@ def test_export_cycle_suppresses_instrumentation(spool: Spool, otlp_server: Stub
             force_flush=lambda timeout_millis=30_000: suppressed_flags.append(not is_instrumentation_enabled())
         )
     )
-    worker = ExportWorker(spool, cast("Any", processor_stub), cast("Any", processor_stub), env="dev")
+    worker = ExportWorker(
+        spool,
+        cast("Any", processor_stub),
+        cast("Any", processor_stub),
+        make_log_provider(spool).get_logger("apitally"),
+        env="dev",
+    )
     worker.session.hooks["response"] = [
         lambda response, **kwargs: suppressed_flags.append(not is_instrumentation_enabled())
     ]
@@ -346,16 +399,36 @@ def test_export_cycle_suppresses_instrumentation(spool: Spool, otlp_server: Stub
     assert is_instrumentation_enabled()
 
 
-def test_shutdown_performs_final_drain_and_stops_thread(
+def test_shutdown_waits_for_active_cycle_and_emits_pending_error_groups(
     spool: Spool, otlp_server: StubOTLPServer, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 60.0)
+    cycle_started = threading.Event()
+    release_cycle = threading.Event()
+
+    def block_cycle(path: str) -> tuple[int, dict[str, str]]:
+        if path == "/v1/traces" and not release_cycle.is_set():
+            cycle_started.set()
+            release_cycle.wait(5)
+        return (200, {})
+
+    otlp_server.respond = block_cycle
+    monkeypatch.setattr(export, "INITIAL_EXPORT_DELAY", 0.01)
     worker = make_worker(spool, otlp_server.url)
-    worker.start()
     spool.append("traces", b"final-payload")
-    worker.shutdown()
+    worker.start()
+    assert cycle_started.wait(5)
+    server_errors.add_server_error(None, "GET", "/items", ExceptionHolder(RuntimeError("boom")))
+
+    shutdown_thread = threading.Thread(target=worker.shutdown)
+    shutdown_thread.start()
+    shutdown_thread.join(0.05)
+    assert shutdown_thread.is_alive()
+    release_cycle.set()
+    shutdown_thread.join(5)
+
+    assert not shutdown_thread.is_alive()
     assert unwrap(worker.thread).is_alive() is False
-    assert otlp_server.paths() == ["/v1/traces"]
+    assert sorted(otlp_server.paths()) == ["/v1/logs", "/v1/traces"]
     assert spool.pending_files() == []
 
 
@@ -427,6 +500,7 @@ def test_export_worker_uses_proxies(spool: Spool, otlp_server: StubOTLPServer, m
         spool,
         cast("Any", processor_stub),
         cast("Any", processor_stub),
+        make_log_provider(spool).get_logger("apitally"),
         env="dev",
         proxy_urls=resolve_proxy_urls(),
     )

--- a/tests/shared/test_helpers.py
+++ b/tests/shared/test_helpers.py
@@ -2,6 +2,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.trace import SpanKind, Tracer
 
 from apitally import capture_exception, set_request_attribute
+from apitally.shared import server_errors
 from apitally.shared.context import get_server_span
 from tests.conftest import unwrap
 
@@ -16,6 +17,13 @@ def test_set_request_attribute_targets_server_span(tracer: Tracer, span_exporter
 def test_set_request_attribute_outside_request_is_silent_noop():
     assert get_server_span() is None
     set_request_attribute("tenant", "acme")
+
+
+def test_capture_exception_updates_holder_without_recording_span():
+    holder = server_errors.init_exception_holder()
+    exception = ValueError("x")
+    capture_exception(exception)
+    assert holder.exception is exception
 
 
 def test_capture_exception_records_event_on_server_span(tracer: Tracer, span_exporter: InMemorySpanExporter):

--- a/tests/shared/test_sentry.py
+++ b/tests/shared/test_sentry.py
@@ -9,7 +9,7 @@ from opentelemetry.sdk.trace.export import BatchSpanProcessor
 from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanExporter
 from opentelemetry.trace import SpanKind
 
-from apitally.shared import activation, sentry
+from apitally.shared import activation, sentry, server_errors
 from apitally.shared.exporter import ApitallySpanExporter
 from apitally.shared.span_processor import ApitallySpanProcessor
 from tests.conftest import CONTRIB_SCOPE, INSTANCE_ID, WRITE_TOKEN
@@ -48,6 +48,13 @@ def initialize_sentry() -> Generator[None]:
     )
     yield
     sentry_sdk.get_client().close()
+
+
+def test_sentry_event_id_reaches_exception_holder_without_retained_span():
+    holder = server_errors.init_exception_holder()
+    sentry.sentry_event_processor({"exception": {}, "event_id": "event-id"}, {})
+    assert holder.sentry_event_id == "event-id"
+    assert sentry.pending_event_ids == {}
 
 
 def test_sentry_event_id_written_after_server_span_ended():

--- a/tests/shared/test_server_errors.py
+++ b/tests/shared/test_server_errors.py
@@ -1,0 +1,155 @@
+import threading
+from contextvars import copy_context
+from typing import Any
+
+from apitally.shared import server_errors
+from apitally.shared.server_errors import ExceptionHolder
+
+
+def test_mutable_exception_holder_is_shared_with_copied_context() -> None:
+    holder = server_errors.init_exception_holder()
+    exception = RuntimeError("boom")
+    copy_context().run(server_errors.set_exception, exception)
+    assert holder.exception is exception
+
+
+def test_exception_replacement_collapse_and_sentry_id_rules() -> None:
+    holder = server_errors.init_exception_holder()
+    first = ValueError("first")
+    server_errors.set_sentry_event_id(" a" * 32)
+    server_errors.set_exception(first)
+    first_event_id = holder.sentry_event_id
+    assert first_event_id is not None
+    assert len(first_event_id) == server_errors.MAX_SENTRY_EVENT_ID_LENGTH
+
+    exception_group_type: Any = server_errors.exception_group_types[0]
+    server_errors.set_exception(exception_group_type("group", [first]))
+    assert holder.exception is first
+    assert holder.sentry_event_id == first_event_id
+
+    second = RuntimeError("second")
+    server_errors.set_exception(second)
+    assert holder.exception is second
+    assert holder.sentry_event_id is None
+    server_errors.set_sentry_event_id("   ")
+    assert holder.sentry_event_id is None
+    server_errors.set_sentry_event_id("event-id")
+    assert holder.sentry_event_id == "event-id"
+
+
+def test_exception_formatting_preserves_v0_markers_and_trailing_traceback_lines() -> None:
+    exception = RuntimeError("é" * (server_errors.MAX_EXCEPTION_MESSAGE_LENGTH + 1))
+    message = server_errors.format_exception_message(exception)
+    assert len(message) == server_errors.MAX_EXCEPTION_MESSAGE_LENGTH
+    assert message.endswith(server_errors.MESSAGE_TRUNCATION_SUFFIX)
+
+    try:
+        try:
+            raise ValueError("x" * server_errors.MAX_STACKTRACE_LENGTH)
+        except ValueError as cause:
+            raise RuntimeError("final") from cause
+    except RuntimeError as chained:
+        stacktrace = server_errors.format_exception_stacktrace(chained)
+    assert len(stacktrace) <= server_errors.MAX_STACKTRACE_LENGTH
+    assert stacktrace.startswith(server_errors.STACKTRACE_TRUNCATION_PREFIX.strip())
+    assert stacktrace.endswith("RuntimeError: final")
+    assert server_errors.format_exception_type(exception) == "builtins.RuntimeError"
+
+
+def test_server_error_eligibility_requires_exception_route_and_non_options_method() -> None:
+    holder = ExceptionHolder(RuntimeError("boom"))
+    server_errors.add_server_error(None, "OPTIONS", "/items", holder)
+    server_errors.add_server_error(None, "GET", None, holder)
+    server_errors.add_server_error(None, "GET", "/items", ExceptionHolder())
+    assert server_errors.drain_server_errors() == []
+
+    server_errors.add_server_error(None, "get", "/items", holder)
+    (body,) = server_errors.drain_server_errors()
+    assert body["method"] == "GET"
+    assert body["path"] == "/items"
+    assert body["type"] == "builtins.RuntimeError"
+    assert body["message"] == "boom"
+    assert body["count"] == 1
+    assert "consumer" not in body
+    assert "sentry_event_id" not in body
+
+
+def test_equal_server_errors_sum_and_latest_non_empty_sentry_id_wins() -> None:
+    exception = RuntimeError("boom")
+    server_errors.add_server_error("consumer", "GET", "/items", ExceptionHolder(exception, "first"))
+    server_errors.add_server_error("consumer", "GET", "/items", ExceptionHolder(exception))
+    server_errors.add_server_error("consumer", "GET", "/items", ExceptionHolder(exception, "last"))
+
+    (body,) = server_errors.drain_server_errors()
+    assert body["consumer"] == "consumer"
+    assert body["count"] == 3
+    assert body["sentry_event_id"] == "last"
+
+
+def test_each_server_error_identity_field_separates_groups() -> None:
+    base = RuntimeError("boom")
+    variants = [
+        ("consumer", "GET", "/items", base),
+        (None, "POST", "/items", base),
+        (None, "GET", "/other", base),
+        (None, "GET", "/items", ValueError("boom")),
+        (None, "GET", "/items", RuntimeError("other")),
+    ]
+    for consumer, method, path, exception in variants:
+        server_errors.add_server_error(consumer, method, path, ExceptionHolder(exception))
+
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError as exception_with_traceback:
+        server_errors.add_server_error(None, "GET", "/items", ExceptionHolder(exception_with_traceback))
+    assert len(server_errors.drain_server_errors()) == len(variants) + 1
+
+
+def test_character_limits_are_applied_before_server_error_grouping() -> None:
+    first = RuntimeError("é" * server_errors.MAX_STACKTRACE_LENGTH + "a")
+    second = RuntimeError("é" * server_errors.MAX_STACKTRACE_LENGTH + "b")
+    server_errors.add_server_error(None, "é" * 12 + "a", "é" * 2_000 + "a", ExceptionHolder(first))
+    server_errors.add_server_error(None, "é" * 12 + "b", "é" * 2_000 + "b", ExceptionHolder(second))
+
+    events = server_errors.drain_server_errors()
+    assert len(events) == 1
+    assert events[0]["count"] == 2
+    assert len(events[0]["method"]) == 12
+    assert len(events[0]["path"]) == 2_000
+    assert len(events[0]["message"]) == server_errors.MAX_EXCEPTION_MESSAGE_LENGTH
+    assert len(events[0]["stacktrace"]) <= server_errors.MAX_STACKTRACE_LENGTH
+
+    long_type = type("É" * 300, (Exception,), {})
+    assert len(server_errors.format_exception_type(long_type())) == server_errors.MAX_EXCEPTION_TYPE_LENGTH
+
+
+def test_server_error_identity_cap_keeps_incrementing_retained_groups() -> None:
+    for index in range(server_errors.MAX_GROUPS + 1):
+        server_errors.add_server_error(None, "GET", "/items", ExceptionHolder(RuntimeError(str(index))))
+    server_errors.add_server_error(None, "GET", "/items", ExceptionHolder(RuntimeError("0")))
+
+    events = server_errors.drain_server_errors()
+    assert len(events) == server_errors.MAX_GROUPS
+    assert next(event for event in events if event["message"] == "0")["count"] == 2
+    assert all(event["message"] != str(server_errors.MAX_GROUPS) for event in events)
+
+
+def test_concurrent_server_error_add_and_drain_preserves_occurrence_count() -> None:
+    start = threading.Event()
+
+    def add_errors() -> None:
+        start.wait()
+        for _ in range(1_000):
+            server_errors.add_server_error(None, "GET", "/items", ExceptionHolder(RuntimeError("boom")))
+
+    threads = [threading.Thread(target=add_errors) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    start.set()
+    count = 0
+    while any(thread.is_alive() for thread in threads):
+        count += sum(event["count"] for event in server_errors.drain_server_errors())
+    for thread in threads:
+        thread.join()
+    count += sum(event["count"] for event in server_errors.drain_server_errors())
+    assert count == 4_000

--- a/tests/shared/test_validation_errors.py
+++ b/tests/shared/test_validation_errors.py
@@ -1,0 +1,171 @@
+import gzip
+import threading
+
+import pytest
+
+from apitally.shared import validation_errors
+from apitally.shared.config import MAX_BODY_SIZE
+from apitally.shared.validation_errors import ValidationError
+
+
+@pytest.mark.parametrize(
+    ("location", "expected"),
+    [
+        (["body", "user", 0, "email"], ("body", "user.0.email")),
+        (["querystring", "page"], ("query", "page")),
+        (["params", "item_id"], ("path", "item_id")),
+        (["headers", "x-token"], ("header", "x-token")),
+        (["cookies", "session"], ("cookie", "session")),
+        (["model", "query", 1, True, None], ("", "model.query.1")),
+        ("body.email", ("", "")),
+        ([], ("", "")),
+    ],
+)
+def test_format_location_uses_only_the_first_segment_as_source(location: object, expected: tuple[str, str]) -> None:
+    assert validation_errors.format_location(location) == expected
+
+
+def test_extract_pydantic_validation_errors_accepts_only_detail_list_fields() -> None:
+    assert validation_errors.extract_pydantic_validation_errors(
+        {
+            "detail": [
+                {"loc": ["path", "item_id"], "msg": "invalid", "type": "int_parsing", "input": "x"},
+                {"loc": ["custom", "query", "value"], "msg": 1, "type": None, "ctx": {}},
+                {},
+                {"message": "ignored"},
+                "ignored",
+            ]
+        }
+    ) == [
+        ValidationError("path", "item_id", "invalid", "int_parsing"),
+        ValidationError("", "custom.query.value", "", ""),
+    ]
+    assert validation_errors.extract_pydantic_validation_errors({"detail": {}}) == []
+    assert validation_errors.extract_pydantic_validation_errors([]) == []
+
+
+def test_equal_validation_errors_drain_with_summed_count_and_required_empty_fields() -> None:
+    error = ValidationError("", "field", "invalid", "")
+    validation_errors.add_validation_errors("consumer", "post", "/items/{item_id}", [error, error])
+    validation_errors.add_validation_errors("consumer", "POST", "/items/{item_id}", [error])
+    validation_errors.add_validation_errors(None, "POST", "/items/{item_id}", [error])
+
+    assert validation_errors.drain_validation_errors() == [
+        {
+            "consumer": "consumer",
+            "method": "POST",
+            "path": "/items/{item_id}",
+            "source": "",
+            "field": "field",
+            "message": "invalid",
+            "type": "",
+            "count": 3,
+        },
+        {
+            "method": "POST",
+            "path": "/items/{item_id}",
+            "source": "",
+            "field": "field",
+            "message": "invalid",
+            "type": "",
+            "count": 1,
+        },
+    ]
+
+
+def test_each_validation_error_identity_field_separates_groups() -> None:
+    base = ValidationError("body", "name", "invalid", "value")
+    variants = [
+        ("other", "POST", "/items", base),
+        (None, "PUT", "/items", base),
+        (None, "POST", "/other", base),
+        (None, "POST", "/items", ValidationError("query", "name", "invalid", "value")),
+        (None, "POST", "/items", ValidationError("body", "other", "invalid", "value")),
+        (None, "POST", "/items", ValidationError("body", "name", "other", "value")),
+        (None, "POST", "/items", ValidationError("body", "name", "invalid", "other")),
+    ]
+    for consumer, method, path, error in variants:
+        validation_errors.add_validation_errors(consumer, method, path, [error])
+    assert len(validation_errors.drain_validation_errors()) == len(variants)
+
+
+def test_character_limits_are_applied_before_validation_error_grouping() -> None:
+    prefix = "é"
+    first = ValidationError(prefix * 32 + "a", prefix * 2_048 + "a", prefix * 2_048 + "a", prefix * 128 + "a")
+    second = ValidationError(prefix * 32 + "b", prefix * 2_048 + "b", prefix * 2_048 + "b", prefix * 128 + "b")
+    validation_errors.add_validation_errors(None, prefix * 12 + "a", prefix * 2_000 + "a", [first])
+    validation_errors.add_validation_errors(None, prefix * 12 + "b", prefix * 2_000 + "b", [second])
+
+    (body,) = validation_errors.drain_validation_errors()
+    assert body == {
+        "method": prefix.upper() * 12,
+        "path": prefix * 2_000,
+        "source": prefix * 32,
+        "field": prefix * 2_048,
+        "message": prefix * 2_048,
+        "type": prefix * 128,
+        "count": 2,
+    }
+
+
+def test_validation_error_identity_cap_keeps_incrementing_retained_groups() -> None:
+    for index in range(validation_errors.MAX_GROUPS + 1):
+        validation_errors.add_validation_errors(None, "GET", "/items", [ValidationError("query", str(index), "x", "")])
+    retained = ValidationError("query", "0", "x", "")
+    validation_errors.add_validation_errors(None, "GET", "/items", [retained])
+
+    events = validation_errors.drain_validation_errors()
+    assert len(events) == validation_errors.MAX_GROUPS
+    assert next(event for event in events if event["field"] == "0")["count"] == 2
+    assert all(event["field"] != str(validation_errors.MAX_GROUPS) for event in events)
+
+
+@pytest.mark.parametrize(
+    ("content_type", "expected"),
+    [
+        ("application/json", True),
+        ("Application/Problem+JSON; charset=utf-8", True),
+        (b"application/vnd.api+json", True),
+        ("application/x-ndjson", False),
+        ("text/json", False),
+        (None, False),
+    ],
+)
+def test_json_content_type_recognition(content_type: str | bytes | None, expected: bool) -> None:
+    assert validation_errors.is_json_content_type(content_type) is expected
+
+
+def test_json_response_decoding_supports_identity_and_bounded_gzip() -> None:
+    body = b'{"detail": []}'
+    assert validation_errors.decode_json_response(body, None) == {"detail": []}
+    assert validation_errors.decode_json_response(body, "identity") == {"detail": []}
+    assert validation_errors.decode_json_response(gzip.compress(body), b"gzip") == {"detail": []}
+    assert validation_errors.decode_json_response(b"{", None) is None
+    assert validation_errors.decode_json_response(body, "br") is None
+    assert validation_errors.decode_json_response(b"not gzip", "gzip") is None
+    assert validation_errors.decode_json_response(gzip.compress(body)[:-2], "gzip") is None
+    oversized_json = b'{"padding":"' + b"x" * MAX_BODY_SIZE + b'"}'
+    assert validation_errors.decode_json_response(oversized_json, None) is None
+    assert validation_errors.decode_json_response(gzip.compress(oversized_json), "gzip") is None
+
+
+def test_concurrent_validation_add_and_drain_preserves_occurrence_count() -> None:
+    error = ValidationError("body", "name", "required", "missing")
+    start = threading.Event()
+
+    def add_errors() -> None:
+        start.wait()
+        for _ in range(1_000):
+            validation_errors.add_validation_errors(None, "POST", "/items", [error])
+
+    threads = [threading.Thread(target=add_errors) for _ in range(4)]
+    for thread in threads:
+        thread.start()
+    start.set()
+    count = 0
+    while any(thread.is_alive() for thread in threads):
+        count += sum(event["count"] for event in validation_errors.drain_validation_errors())
+    for thread in threads:
+        thread.join()
+    count += sum(event["count"] for event in validation_errors.drain_validation_errors())
+    assert count == 4_000

--- a/tests/shared/test_wsgi.py
+++ b/tests/shared/test_wsgi.py
@@ -13,7 +13,7 @@ from opentelemetry.sdk.trace.export.in_memory_span_exporter import InMemorySpanE
 from opentelemetry.sdk.trace.sampling import ALWAYS_ON
 from opentelemetry.trace import SpanKind, Tracer
 
-from apitally.shared import metrics
+from apitally.shared import metrics, server_errors
 from apitally.shared.config import BODY_TOO_LARGE, set_config
 from apitally.shared.redaction import REDACTED, Redaction
 from apitally.shared.span_processor import ApitallySpanProcessor
@@ -80,6 +80,10 @@ def make_environ(
         environ["CONTENT_LENGTH"] = content_length
     environ.update(extra)
     return environ
+
+
+def ignore_start_response(status: str, headers: list[tuple[str, str]], exc_info: Any = None) -> Any:
+    return lambda body: None
 
 
 def run_request(
@@ -350,3 +354,58 @@ def test_exception_after_response_start_records_metrics(
     (point,) = duration_metric.data.data_points
     assert point.count == 1
     assert (point.attributes or {})["http.response.status_code"] == 200
+    assert server_errors.drain_server_errors() == []
+
+
+def test_escaping_wsgi_application_exception_is_added_without_recording_span():
+    set_config(write_token=WRITE_TOKEN)
+
+    def app(environ: WSGIEnvironment, start_response: StartResponse) -> list[bytes]:
+        raise RuntimeError("application failed")
+
+    middleware = ApitallyWSGIMiddleware(app, get_route=lambda environ: "/items")
+    with pytest.raises(RuntimeError):
+        middleware(make_environ(), ignore_start_response)
+
+    (event,) = server_errors.drain_server_errors()
+    assert event["message"] == "application failed"
+    assert event["count"] == 1
+
+
+def test_wsgi_iterator_exception_is_added_without_recording_span():
+    set_config(write_token=WRITE_TOKEN)
+
+    def app(environ: WSGIEnvironment, start_response: StartResponse) -> Iterator[bytes]:
+        start_response("500 Internal Server Error", [])
+
+        def content() -> Iterator[bytes]:
+            yield b"first"
+            raise RuntimeError("iterator failed")
+
+        return content()
+
+    response = ApitallyWSGIMiddleware(app, get_route=lambda environ: "/items")(make_environ(), ignore_start_response)
+    iterator = iter(response)
+    assert next(iterator) == b"first"
+    with pytest.raises(RuntimeError):
+        next(iterator)
+
+    (event,) = server_errors.drain_server_errors()
+    assert event["message"] == "iterator failed"
+    assert event["count"] == 1
+
+
+def test_wsgi_iterable_completion_and_close_add_server_error_once():
+    set_config(write_token=WRITE_TOKEN)
+
+    def app(environ: WSGIEnvironment, start_response: StartResponse) -> list[bytes]:
+        server_errors.set_exception(RuntimeError("boom"))
+        start_response("500 Internal Server Error", [])
+        return [b"error"]
+
+    response = ApitallyWSGIMiddleware(app, get_route=lambda environ: "/items")(make_environ(), ignore_start_response)
+    assert list(response) == [b"error"]
+    response.close()  # ty: ignore[unresolved-attribute]
+
+    (event,) = server_errors.drain_server_errors()
+    assert event["count"] == 1

--- a/tests/test_blacksheep.py
+++ b/tests/test_blacksheep.py
@@ -2,7 +2,7 @@ import inspect
 import json
 from importlib.metadata import version
 from ipaddress import ip_address
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -22,6 +22,7 @@ from tests.conftest import (
     attach_metric_reader,
     attach_stale_server_span,
     duration_data_points,
+    exported_error_records,
     exported_spans,
     startup_payload,
 )
@@ -231,6 +232,11 @@ async def test_unhandled_exception_recorded_on_server_span(
     (event,) = [event for event in span.events if event.name == "exception"]
     assert (event.attributes or {})["exception.type"] == "ValueError"
     assert (event.attributes or {})["exception.message"] == "boom"
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["type"] == "builtins.ValueError"
+    assert body["message"] == "boom"
 
 
 async def test_init_twice_does_not_stack_middleware(exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_django.py
+++ b/tests/test_django.py
@@ -1,7 +1,7 @@
 import json
 import sys
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, cast
 
 import django
 import pytest
@@ -15,7 +15,7 @@ from opentelemetry.trace import SpanKind
 
 import apitally
 from apitally.django import APITALLY_MIDDLEWARE, OTEL_MIDDLEWARE, _convert_proxy_objects
-from apitally.shared import activation, config
+from apitally.shared import activation, config, server_errors
 from apitally.shared.config import BODY_TOO_LARGE
 from apitally.shared.redaction import REDACTED
 from tests.conftest import (
@@ -24,6 +24,7 @@ from tests.conftest import (
     attach_metric_reader,
     collect_metrics,
     duration_data_points,
+    exported_error_records,
     exported_spans,
     startup_payload,
     unwrap,
@@ -199,6 +200,30 @@ def test_streaming_response_size_and_body_captured(exporters: InMemoryExporters,
     assert size_point.sum == 12
 
 
+def test_streaming_exception_reports_one_server_error_with_late_sentry_id(
+    exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
+):
+    init(monkeypatch)
+    activate_via_signal()
+
+    response = Client().get("/stream/?fail=1")
+    assert response.status_code == 500
+    iterator = iter(response.streaming_content)  # ty: ignore[unresolved-attribute]
+    assert next(iterator) == b"chunk1"
+    with pytest.raises(RuntimeError, match="stream failed"):
+        next(iterator)
+    server_errors.set_sentry_event_id("late-event-id")
+
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["path"] == "/stream/"
+    assert body["type"] == "builtins.RuntimeError"
+    assert body["message"] == "stream failed"
+    assert body["sentry_event_id"] == "late-event-id"
+    assert body["count"] == 1
+
+
 def test_no_response_size_when_client_stops_reading_mid_stream(
     exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
 ):
@@ -303,6 +328,12 @@ def test_unhandled_exception_recorded_on_server_span(exporters: InMemoryExporter
     (point,) = duration_data_points(reader)
     assert (point.attributes or {})["http.response.status_code"] == 500
     assert (point.attributes or {})["error.type"] == "500"
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["type"] == "builtins.ValueError"
+    assert body["message"] == "boom"
+    assert body["count"] == 1
 
 
 def test_pre_instrumented_app_adapts_without_duplicate_spans(

--- a/tests/test_django_ninja.py
+++ b/tests/test_django_ninja.py
@@ -1,5 +1,6 @@
 import json
 from collections.abc import Iterator
+from typing import Any, cast
 
 import pytest
 from django.test import Client
@@ -9,6 +10,7 @@ from tests.conftest import (
     InMemoryExporters,
     attach_metric_reader,
     duration_data_points,
+    exported_error_records,
     exported_spans,
     startup_payload,
 )
@@ -64,3 +66,18 @@ def test_request_flow(exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPa
     assert span.attributes["http.response.status_code"] == 200
     (point,) = duration_data_points(reader)
     assert (point.attributes or {})["http.route"] == "/api/foo/{bar}"
+
+
+def test_validation_error_uses_path_source_and_route(exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch):
+    init(monkeypatch)
+    activate_via_signal()
+
+    response = Client().get("/api/foo/not-an-int")
+    assert response.status_code == 422
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.validation_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["path"] == "/api/foo/{bar}"
+    assert body["source"] == "path"
+    assert body["field"] == "bar"
+    assert body["count"] == 1

--- a/tests/test_fastapi.py
+++ b/tests/test_fastapi.py
@@ -1,7 +1,7 @@
 import json
 import logging
 from collections.abc import Iterator
-from typing import Any
+from typing import Any, cast
 
 import httpx
 import pytest
@@ -22,6 +22,7 @@ from tests.conftest import (
     attach_metric_reader,
     attach_stale_server_span,
     duration_data_points,
+    exported_error_records,
     exported_log_records,
     exported_spans,
     startup_payload,
@@ -204,6 +205,25 @@ def test_mounted_subapp_route_in_metrics_and_startup_paths(
     assert {"method": "GET", "path": "/sub/things/{thing_id}"} in payload["paths"]
 
 
+def test_unmatched_request_has_no_route_and_no_histogram_point(
+    app: FastAPI, exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
+):
+    orders_app = FastAPI()
+
+    @orders_app.get("/{order_id}")
+    def get_order(order_id: int) -> dict[str, int]:
+        return {"order_id": order_id}
+
+    app.mount("/orders", orders_app)
+    init(app, monkeypatch)
+    with TestClient(app) as client:
+        reader = attach_metric_reader()
+        response = client.get("/login")
+
+    assert response.status_code == 404
+    assert duration_data_points(reader) == []
+
+
 def test_pre_instrumented_app_adapts_without_duplicate_spans(
     app: FastAPI, exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
 ):
@@ -233,6 +253,70 @@ def test_unhandled_exception_recorded_on_server_span(
     (event,) = [e for e in span.events if e.name == "exception"]
     assert unwrap(event.attributes)["exception.type"] == "ValueError"
     assert unwrap(event.attributes)["exception.message"] == "boom"
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["type"] == "builtins.ValueError"
+    assert body["message"] == "boom"
+    assert body["count"] == 1
+
+
+def test_validation_error_reported_without_request_trace(
+    app: FastAPI, exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
+):
+    init(app, monkeypatch, sample_rate=0.0)
+    with TestClient(app) as client:
+        response = client.get("/items/not-an-int")
+    assert response.status_code == 422
+    assert exported_spans(exporters) == []
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.validation_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["method"] == "GET"
+    assert body["path"] == "/items/{item_id}"
+    assert body["source"] == "path"
+    assert body["field"] == "item_id"
+    assert body["count"] == 1
+
+
+@pytest.mark.parametrize(
+    ("path", "event_name"),
+    [
+        ("/items/not-an-int", "apitally.request.validation_error"),
+        ("/error", "apitally.request.server_error"),
+    ],
+)
+def test_excluded_route_still_reports_errors_without_trace(
+    app: FastAPI,
+    exporters: InMemoryExporters,
+    monkeypatch: pytest.MonkeyPatch,
+    path: str,
+    event_name: str,
+):
+    init(app, monkeypatch, exclude_paths=[path])
+    with TestClient(app, raise_server_exceptions=False) as client:
+        client.get(path)
+    assert exported_spans(exporters) == []
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == event_name
+
+
+def test_server_error_before_routing_uses_registered_route(
+    app: FastAPI, exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
+):
+    @app.middleware("http")
+    async def fail_before_routing(request: Any, call_next: Any) -> Any:
+        raise RuntimeError("middleware failed")
+
+    init(app, monkeypatch)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/items/42")
+    assert response.status_code == 500
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["path"] == "/items/{item_id}"
+    assert body["message"] == "middleware failed"
 
 
 def test_unhandled_exception_with_http_middleware_recorded_unwrapped(

--- a/tests/test_flask.py
+++ b/tests/test_flask.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Iterator
+from typing import Any, Iterator, cast
 
 import pytest
 from flask import Blueprint, Flask, Response, jsonify
@@ -18,6 +18,7 @@ from tests.conftest import (
     InMemoryExporters,
     attach_metric_reader,
     duration_data_points,
+    exported_error_records,
     exported_spans,
     startup_payload,
     unwrap,
@@ -307,6 +308,11 @@ def test_unhandled_exception_recorded_on_server_span(
     (event,) = [e for e in span.events if e.name == "exception"]
     assert (event.attributes or {})["exception.type"] == "ValueError"
     assert (event.attributes or {})["exception.message"] == "boom"
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["type"] == "builtins.ValueError"
+    assert body["message"] == "boom"
 
 
 def test_pre_instrumented_app_adapts_without_duplicate_spans(
@@ -323,3 +329,39 @@ def test_pre_instrumented_app_adapts_without_duplicate_spans(
     assert attributes["http.route"] == "/items/<int:item_id>"
     # The Apitally middleware still sets its attributes on the span created by the user's instrumentation
     assert "http.response.header.content-type" in attributes
+
+    error_response = app.test_client().get("/error")
+    assert error_response.status_code == 500
+    assert error_response.data
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["message"] == "boom"
+
+
+def test_sample_rate_zero_drops_trace_but_keeps_server_error(
+    app: Flask, exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
+):
+    init(app, monkeypatch, sample_rate=0.0)
+    response = app.test_client().get("/error")
+    assert response.status_code == 500
+    assert response.data
+    assert exported_spans(exporters) == []
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["message"] == "boom"
+
+
+def test_deliberate_503_without_exception_does_not_report(
+    app: Flask, exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
+):
+    @app.get("/unavailable")
+    def unavailable() -> tuple[str, int]:
+        return "unavailable", 503
+
+    init(app, monkeypatch)
+    response = app.test_client().get("/unavailable")
+    assert response.status_code == 503
+    assert response.data
+    assert exported_error_records(exporters) == []

--- a/tests/test_litestar.py
+++ b/tests/test_litestar.py
@@ -1,7 +1,7 @@
 import json
 import platform
 from importlib import metadata
-from typing import Any
+from typing import Any, cast
 
 import pytest
 from litestar import Litestar, Router, get, post
@@ -27,6 +27,7 @@ from tests.conftest import (
     attach_metric_reader,
     attach_stale_server_span,
     duration_data_points,
+    exported_error_records,
     exported_spans,
     startup_payload,
     unwrap,
@@ -175,6 +176,28 @@ def test_unhandled_exception_recorded_on_server_span(exporters: InMemoryExporter
     (event,) = [event for event in span.events if event.name == "exception"]
     assert (event.attributes or {})["exception.type"] == "ValueError"
     assert (event.attributes or {})["exception.message"] == "boom"
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["type"] == "builtins.ValueError"
+    assert body["message"] == "boom"
+
+
+def test_validation_error_uses_litestar_source_and_opaque_key(
+    exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
+):
+    with TestClient(app=make_app(monkeypatch)) as client:
+        response = client.post("/users", json=[])
+    assert response.status_code == 400
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.validation_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["path"] == "/users"
+    assert body["source"] == "body"
+    assert body["field"] == "data"
+    assert body["message"]
+    assert body["type"] == ""
+    assert body["count"] == 1
 
 
 def test_route_includes_router_path_prefix(exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_starlette.py
+++ b/tests/test_starlette.py
@@ -27,6 +27,7 @@ from tests.conftest import (
     attach_metric_reader,
     attach_stale_server_span,
     duration_data_points,
+    exported_error_records,
     exported_log_records,
     exported_spans,
     unwrap,
@@ -177,6 +178,11 @@ def test_unhandled_exception_recorded_on_server_span(
     assert unwrap(event.attributes)["exception.message"] == "boom"
     (point,) = duration_data_points(reader)
     assert unwrap(point.attributes)["http.response.status_code"] == 500
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["type"] == "builtins.ValueError"
+    assert body["message"] == "boom"
 
 
 def test_unhandled_exception_with_http_middleware_recorded_unwrapped(
@@ -204,6 +210,10 @@ def test_unhandled_exception_with_http_middleware_recorded_unwrapped(
         (event,) = [e for e in span.events if e.name == "exception"]
         assert unwrap(event.attributes)["exception.type"] == "ValueError"
         assert unwrap(event.attributes)["exception.message"] == "boom"
+        (record,) = exported_error_records(exporters)
+        body = cast("dict[str, Any]", record.body)
+        assert body["type"] == "builtins.ValueError"
+        assert body["message"] == "boom"
     finally:
         StarletteInstrumentor.uninstrument_app(app)
 
@@ -257,6 +267,22 @@ def test_pre_instrumented_app_adapts_without_duplicate_spans(
     assert isinstance(response_body_size, int) and response_body_size > 0
     (point,) = duration_data_points(reader)
     assert unwrap(point.attributes)["http.route"] == "/items/{item_id}"
+
+
+def test_pre_instrumented_app_reports_escaping_exception(
+    app: Starlette, exporters: InMemoryExporters, monkeypatch: pytest.MonkeyPatch
+):
+    StarletteInstrumentor.instrument_app(app)
+    init(app, monkeypatch)
+    with TestClient(app, raise_server_exceptions=False) as client:
+        response = client.get("/error")
+    assert response.status_code == 500
+    (record,) = exported_error_records(exporters)
+    assert record.event_name == "apitally.request.server_error"
+    body = cast("dict[str, Any]", record.body)
+    assert body["type"] == "builtins.ValueError"
+    assert body["message"] == "boom"
+    assert body["count"] == 1
 
 
 @pytest.mark.parametrize("pre_instrumented", [False, True])


### PR DESCRIPTION
## Summary

- aggregate validation and server errors independently of traces
- emit structured `apitally.request.validation_error` and `apitally.request.server_error` OTLP log events through the existing export and spool pipeline
- capture framework-specific validation details and exceptions across supported ASGI, WSGI, and Django integrations
- preserve late Sentry event ID enrichment for finalized ASGI and failed Django streaming requests
- report detailed server errors only for matched requests with final status exactly 500 and a captured exception

## Testing

- `uv run make check`
- `uv run make test` (364 passed)
- `git diff --check`


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores detailed error reporting by emitting structured `apitally.request.validation_error` and `apitally.request.server_error` OTLP log events independently of trace sampling, instead of relying on server-side derivation from trace exception events.

- Captures framework-specific validation details and exceptions across ASGI, WSGI, and Django integrations.
- Reports server errors only for matched requests with final status exactly 500 and a captured exception.
- Preserves late Sentry event ID enrichment for finalized ASGI and failed Django streaming requests.
- Updates `MIGRATION.md` to reflect the restored SDK-side capture API.

<sup>Written for commit 5dbbe78627b833473e00c44988c727ad70a0dcc2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/apitally/apitally-py/pull/338?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

